### PR TITLE
Fix getModuleDir call

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-require_once( Mage::getModuleDir('base'). 'community/Zendesk/Zendesk/Helper/JWT.php');
+require_once(Mage::getModuleDir('', 'Zendesk_Zendesk') . DS . 'Helper' . DS . 'JWT.php');
 
 class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Controller_Action
 {


### PR DESCRIPTION
> Warning: Missing argument 2 for Mage::getModuleDir(), called in /app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php on line 18 and defined in /app/Mage.php on line 338

This is found when accessing anything that calls the `JWT.php` helper.

I have found this in CE 1.7.0.2. The issue was introduced in 74757fe.

Uses `DS` as directory separator for compatibility reasons.

Reference: http://docs.magentocommerce.com/Mage_Core/Mage_Core_Model_Config.html#getModuleDir

Replaces #10 with a single change PR.
