### PR TITLE
Fix XML ACL to allow Roles to add the Zendesk Menu to Non Full Access Us...

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Menu.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Menu.php
@@ -23,4 +23,13 @@ class Zendesk_Zendesk_Block_Adminhtml_Menu extends Mage_Adminhtml_Block_Template
         $this->setId('page_tabs');
         $this->setTemplate('zendesk/left-menu.phtml');
     }
+
+    public function isAllowed($target)
+    {
+        try {
+            return Mage::getSingleton('admin/session')->isAllowed('admin/zendesk/zendesk_' . $target);
+        } catch (Exception $e) {
+            return false;
+        }
+    }
 }

--- a/src/app/code/community/Zendesk/Zendesk/etc/config.xml
+++ b/src/app/code/community/Zendesk/Zendesk/etc/config.xml
@@ -181,15 +181,19 @@
                             <children>
                                 <zendesk_dashboard translate="title" module="zendesk">
                                     <title>Dashboard</title>
+                                    <sort_order>1</sort_order>
                                 </zendesk_dashboard>
                                 <zendesk_create translate="title" module="zendesk">
                                     <title>Create Ticket</title>
+                                    <sort_order>2</sort_order>
                                 </zendesk_create>
                                 <zendesk_launch translate="title" module="zendesk">
                                     <title>Launch Zendesk</title>
+                                    <sort_order>3</sort_order>
                                 </zendesk_launch>
                                 <zendesk_settings translate="title" module="zendesk">
                                     <title>Settings</title>
+                                    <sort_order>4</sort_order>
                                 </zendesk_settings>
                             </children>
                         </zendesk>

--- a/src/app/code/community/Zendesk/Zendesk/etc/config.xml
+++ b/src/app/code/community/Zendesk/Zendesk/etc/config.xml
@@ -176,7 +176,8 @@
             <resources>
                 <admin>
                     <children>
-                        <zendesk>
+                        <zendesk translate="title" module="zendesk">
+                            <title>Zendesk Dashboard</title>
                             <children>
                                 <zendesk_dashboard translate="title" module="zendesk">
                                     <title>Dashboard</title>

--- a/src/app/design/adminhtml/default/default/template/zendesk/left-menu.phtml
+++ b/src/app/design/adminhtml/default/default/template/zendesk/left-menu.phtml
@@ -17,24 +17,32 @@
 ?>
 <h3>Zendesk</h3>
 <ul class="tabs">
+    <?php if ($this->isAllowed('dashboard')) { ?>
     <li>
         <a href="<?php echo $this->getUrl('*/*/index'); ?>" class="tab-item-link<?php if($this->getActiveItem() == "dashboard") echo ' active'; ?>">
             <span><?php echo $this->__('Dashboard'); ?></span>
         </a>
     </li>
+    <?php } ?>
+    <?php if ($this->isAllowed('create')) { ?>
     <li>
         <a href="<?php echo $this->getUrl('*/*/create'); ?>" class="tab-item-link<?php if($this->getActiveItem() == "create") echo ' active'; ?>">
             <span><?php echo $this->__('Create Ticket'); ?></span>
         </a>
     </li>
+    <?php } ?>
+    <?php if ($this->isAllowed('launch')) { ?>
     <li>
         <a href="<?php echo Mage::helper('zendesk')->getUrl(); ?>" target="_blank" class="tab-item-link">
             <span><?php echo $this->__('Launch Zendesk'); ?></span>
         </a>
     </li>
+    <?php } ?>
+    <?php if ($this->isAllowed('settings')) { ?>
     <li>
         <a href="<?php echo $this->getUrl('adminhtml/system_config/edit/section/zendesk'); ?>" class="tab-item-link">
             <span><?php echo $this->__('Settings'); ?></span>
         </a>
     </li>
+    <?php } ?>
 </ul>


### PR DESCRIPTION
I discovered that the Role Resources was missing the ability to Give the Zendesk Dropdown menu to a user who doesn't have full access. So I fixed the ACL.

It adds the following to the Role Resources Selector:

![administrators___roles___permissions___system___magento_admin](https://f.cloud.github.com/assets/20999/1351318/7e1d801a-3721-11e3-897a-b2b8de8f4670.png)
