### PR TITLE
Bugfixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,16 @@
+{
+    "name": "zookal/zendesk",
+    "license": "OSL-3.0",
+    "type": "magento-module",
+    "description": "Zendesk Extension for Magento Zookal Version",
+    "homepage": "https://github.com/zendesk/magento_extension",
+    "require": {
+        "magento-hackathon/magento-composer-installer": "*"
+    },
+    "authors": [
+        {
+            "name": "Cyrill Schumacher",
+            "email": "cyrill@zookal.com"
+        }
+    ]
+}

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,10 @@
 {
-    "name": "zookal/zendesk",
+    "name": "zendesk/zendesk",
     "license": "OSL-3.0",
     "type": "magento-module",
-    "description": "Zendesk Extension for Magento Zookal Version",
+    "description": "Zendesk Extension for Magento",
     "homepage": "https://github.com/zendesk/magento_extension",
     "require": {
         "magento-hackathon/magento-composer-installer": "*"
-    },
-    "authors": [
-        {
-            "name": "Cyrill Schumacher",
-            "email": "cyrill@zookal.com"
-        }
-    ]
+    }
 }

--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Create/Edit.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Create/Edit.php
@@ -17,6 +17,12 @@
 
 class Zendesk_Zendesk_Block_Adminhtml_Create_Edit extends Mage_Adminhtml_Block_Widget_Form_Container
 {
+    protected function _construct()
+    {
+        parent::_construct();
+        $this->_controller = FALSE;
+    }
+
     protected function _preparelayout()
     {
         $this->removeButton('delete');

--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Create/Edit.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Create/Edit.php
@@ -30,7 +30,7 @@ class Zendesk_Zendesk_Block_Adminhtml_Create_Edit extends Mage_Adminhtml_Block_W
             if(isset($data['order_id'])) {
                 $this->_addButton('back', array(
                      'label'     => Mage::helper('adminhtml')->__('Back'),
-                     'onclick'   => 'setLocation(\'' . $this->getBackUrl($data['order_id']) . '\')',
+                     'onclick'   => 'setLocation(\'' . $this->getZdBackUrl($data['order_id']) . '\')',
                      'class'     => 'back',
                 ), -1);
             }
@@ -44,19 +44,19 @@ class Zendesk_Zendesk_Block_Adminhtml_Create_Edit extends Mage_Adminhtml_Block_W
         $this->setChild('form', $this->getLayout()->createBlock('zendesk/adminhtml_create_edit_form'));
         return parent::_prepareLayout();
     }
-    
+
     public function getFormHtml()
     {
         $formHtml = parent::getFormHtml();
         return $formHtml;
     }
-    
+
     public function getHeaderText()
     {
         return Mage::helper('zendesk')->__('New Ticket');
     }
 
-    public function getBackUrl($orderId)
+    public function getZdBackUrl($orderId)
     {
         if (Mage::getSingleton('admin/session')->isAllowed('sales/order/actions/view')) {
             return $this->getUrl('adminhtml/sales_order/view', array('order_id' => $orderId));


### PR DESCRIPTION
Hi,

these bug occur when using Magento 1.7.

[BUGFIX] Setting property _controller to false. Exception 'Mage_Core_Exception' with message 'Invalid block type: Mage_Adminhtml_Block_Empty_Edit_Form'

[BUGFIX] Zendesk_Zendesk_Block_Adminhtml_Create_Edit::getBackUrl() should be compatible with Mage_Adminhtml_Block_Widget_Form_Container::getBackUrl()

Also added a composer.json file.

Thanks for merging!

Cyrill
