### PR TITLE
[BUG] Strip slashes from the authorization header

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
@@ -23,7 +23,7 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
         // Perform some basic checks before running any of the API methods
         // Note that authorisation will accept either the provisioning or the standard API token, which facilitates API
         // methods being called during the setup process
-        $tokenString = $this->getRequest()->getHeader('authorization');
+        $tokenString = stripslashes($this->getRequest()->getHeader('authorization'));
 
         $token = null;
         $matches = array();


### PR DESCRIPTION
:koala: :bug: 

This PR fixes a long standing issue where the authorization token would fail to match the regex because some servers escape quotes in the request headers.

/cc @jwswj @chnorton
