### PR TITLE
Added check for authorization header

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
@@ -23,7 +23,14 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
         // Perform some basic checks before running any of the API methods
         // Note that authorisation will accept either the provisioning or the standard API token, which facilitates API
         // methods being called during the setup process
-        $tokenString = stripslashes($this->getRequest()->getHeader('authorization'));
+        $authHeader = $this->getRequest()->getHeader('authorization');
+
+        if (!$authHeader) {
+            Mage::log('Unable to extract authorization header from request', null, 'zendesk.log');
+            return false;
+        }
+
+        $tokenString = stripslashes($authHeader);
 
         $token = null;
         $matches = array();


### PR DESCRIPTION
:koala: :+1: 

This PR adds a check for the authorisation header to provide more meaningful logging. The method [`getHeader`](http://www.pata.cat/tools/zend-framework-1.10/doxygen/class_zend___controller___request___http.html#aab81e43916cdc2d7c29fd4beb9f52519) firstly tries to extract the headers from the [`$_SERVER`](http://php.net/manual/en/reserved.variables.server.php) array. If it can't find it there it tries the [`apache_request_headers`](http://www.php.net/manual/en/function.apache-request-headers.php) function, which was not available under FastCGI until PHP 5.4. This results in some servers failing to authenticate with the API.

/cc @jwswj @maximeprades @chnorton
