### PR TITLE
Enable/disable external_id param while usign SSO

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
@@ -175,4 +175,14 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
 
         return $customer;
     }
+
+    /**
+     * Retrieve Use External ID config option
+     *
+     * @return integer
+     */
+    public function isExternalIdEnabled()
+    {
+        return Mage::getStoreConfig('zendesk/general/use_external_id');
+    }
 }

--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -93,7 +93,7 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
         );
 
         // Validate if we need to include external_id param
-        $externalIdEnabled = Mage::getStoreConfig('zendesk/general/use_external_id');
+        $externalIdEnabled = Mage::helper('zendesk')->isExternalIdEnabled();
         if($externalIdEnabled) {
             $payload['external_id'] = $user->getId();
         }

--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -86,12 +86,17 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
         $externalId = $user->getId();
 
         $payload = array(
-          "iat" => $now,
-          "jti" => $jti,
-          "name" => $name,
-          "email" => $email,
-          "external_id" => $externalId
+            "iat" => $now,
+            "jti" => $jti,
+            "name" => $name,
+            "email" => $email
         );
+
+        // Validate if we need to include external_id param
+        $externalIdEnabled = Mage::getStoreConfig('zendesk/general/use_external_id');
+        if($externalIdEnabled) {
+            $payload['external_id'] = $user->getId();
+        }
 
         Mage::log('Admin JWT: ' . var_export($payload, true), null, 'zendesk.log');
 

--- a/src/app/code/community/Zendesk/Zendesk/controllers/SsoController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/SsoController.php
@@ -65,9 +65,14 @@ class Zendesk_Zendesk_SsoController extends Mage_Core_Controller_Front_Action
             "iat" => $now,
             "jti" => $jti,
             "name" => $name,
-            "email" => $email,
-            "external_id" => $externalId
+            "email" => $email
         );
+
+        // Validate if we need to include external_id param
+        $externalIdEnabled = Mage::getStoreConfig('zendesk/general/use_external_id');
+        if($externalIdEnabled) {
+            $payload['external_id'] = $user->getId();
+        }
 
         Mage::log('End-user JWT: ' . var_export($payload, true), null, 'zendesk.log');
 

--- a/src/app/code/community/Zendesk/Zendesk/controllers/SsoController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/SsoController.php
@@ -69,7 +69,7 @@ class Zendesk_Zendesk_SsoController extends Mage_Core_Controller_Front_Action
         );
 
         // Validate if we need to include external_id param
-        $externalIdEnabled = Mage::getStoreConfig('zendesk/general/use_external_id');
+        $externalIdEnabled = Mage::helper('zendesk')->isExternalIdEnabled();
         if($externalIdEnabled) {
             $payload['external_id'] = $user->getId();
         }

--- a/src/app/code/community/Zendesk/Zendesk/etc/system.xml
+++ b/src/app/code/community/Zendesk/Zendesk/etc/system.xml
@@ -80,6 +80,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </test>
+                        <use_external_id>
+                            <label>Use External ID</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>5</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Depending on your Zendesk configuration under "Settings / Security / JSON Web Token / Update of external IDs?" ]]></comment>
+                        </use_external_id>
                     </fields>
                 </general>
                 <sso translate="label comment">


### PR DESCRIPTION
This config option allows to enable/disable the use of external_id param when using SSO in controllers.
By default, this option is passed and login using 'I am Agent' doesn't work.
