### PR TITLE
Respond with 403 if Authorization header is not present

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
@@ -27,7 +27,7 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
 
         if(!$tokenString && isset($_SERVER['Authorization'])) {
             $tokenString = $_SERVER['Authorization'];
-		}
+        }
 
         if(!$tokenString && isset($_SERVER['HTTP_AUTHORIZATION'])) {
             $tokenString = $_SERVER['HTTP_AUTHORIZATION'];

--- a/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
@@ -51,10 +51,6 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
         $matches = array();
         if(preg_match('/Token token="([a-z0-9]+)"/', $tokenString, $matches)) {
             $token = $matches[1];
-        } else {
-            // sometimes preg_match fails to retrieve token, so we explode
-            $apiToken = explode("=", $tokenString);
-            $token = str_replace('"', '', $apiToken[1]);
         }
 
         $apiToken = Mage::helper('zendesk')->getApiToken(false);

--- a/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
@@ -26,7 +26,14 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
         $authHeader = $this->getRequest()->getHeader('authorization');
 
         if (!$authHeader) {
-            Mage::log('Unable to extract authorization header from request', null, 'zendesk.log');
+            // Certain server configurations fail to extract headers from the request, see PR #24.
+            $this->getResponse()
+                ->setBody(json_encode(array('success' => false, 'message' => 'Unable to extract authorization header from request')))
+                ->setHttpResponseCode(403)
+                ->setHeader('Content-type', 'application/json', true);
+
+            Mage::log('Unable to extract authorization header from request.', null, 'zendesk.log');
+
             return false;
         }
 


### PR DESCRIPTION
:koala: :bug: 

This PR fixes an issue where the API would return 200 with an empty response body if there was no Authorization header in the request. This is causing the Setup guide to fail silently for some users.

/cc @jwswj @maximeprades @ebizmarts
