### PR TITLE
Customer's account : New section My Tickets

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Customer/Tickets.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Customer/Tickets.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Copyright 2012 Zendesk.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class Zendesk_Zendesk_Block_Customer_Tickets extends Mage_Core_Block_Template
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setTemplate('zendesk/customer/tickets.phtml');
+    }
+}

--- a/src/app/code/community/Zendesk/Zendesk/Block/Customer/Tickets/List.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Customer/Tickets/List.php
@@ -20,6 +20,19 @@ class Zendesk_Zendesk_Block_Customer_Tickets_List extends Mage_Core_Block_Templa
     public function __construct()
     {
         parent::__construct();
+
+        $key = array(
+            'ZendeskCustomerTickets',
+            $this->getCustomer()->getId()
+        );
+
+        $this->addData(array(
+            'cache_lifetime' => 60 * 5,
+            'cache_tags' => array('Zendesk_Customer_Tickets'),
+            'cache_key' => implode('_', $key)
+
+        ));
+
         $this->setTemplate('zendesk/customer/tickets/list.phtml');
     }
 

--- a/src/app/code/community/Zendesk/Zendesk/Block/Customer/Tickets/List.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Customer/Tickets/List.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright 2012 Zendesk.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class Zendesk_Zendesk_Block_Customer_Tickets_List extends Mage_Core_Block_Template
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setTemplate('zendesk/customer/tickets/list.phtml');
+    }
+
+
+    protected function _getCustomerSession()
+    {
+        return Mage::getSingleton('customer/session');
+    }
+
+
+    public function getCustomer()
+    {
+        $session = $this->_getCustomerSession();
+        $customer = false;
+
+        if($session) {
+            $customer = $session->getCustomer();
+        }
+
+        return $customer;
+    }
+
+
+    public function getList()
+    {
+        $customer = $this->getCustomer();
+        $tickets = null;
+
+        if($customer) {
+            $tickets = Mage::getModel('zendesk/api_tickets')->forRequester($customer->getEmail());
+        }
+
+        return $tickets;
+    }
+}

--- a/src/app/code/community/Zendesk/Zendesk/controllers/Customer/TicketsController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Customer/TicketsController.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Copyright 2012 Zendesk.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class Zendesk_Zendesk_Customer_TicketsController extends Mage_Core_Controller_Front_Action
+{
+
+    /**
+     * Display data
+     */
+    public function indexAction()
+    {
+        $this->loadLayout();
+
+        $this->renderLayout();
+    }
+
+}

--- a/src/app/code/community/Zendesk/Zendesk/etc/system.xml
+++ b/src/app/code/community/Zendesk/Zendesk/etc/system.xml
@@ -256,6 +256,16 @@
                             <show_in_store>1</show_in_store>
                             <comment><![CDATA[Used to link order in Magento with tickets in Zendesk]]></comment>
                         </order_field_id>
+                        <customer_tickets translate="label comment">
+                            <label>Show Tickets in Customer Accounts</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>20</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                            <comment><![CDATA[Display Customer's tickets in My Account]]></comment>
+                        </customer_tickets>
                     </fields>
                 </features>
                 <api translate="label comment">

--- a/src/app/design/frontend/base/default/layout/zendesk.xml
+++ b/src/app/design/frontend/base/default/layout/zendesk.xml
@@ -19,8 +19,7 @@
 <layout>
     <default>
         <reference name="footer_links">
-            <action method="addLink" translate="label title" module="contacts"
-                    ifconfig="zendesk/features/footer_link_enabled">
+            <action method="addLink" translate="label title" module="contacts" ifconfig="zendesk/features/footer_link_enabled">
                 <label>Support</label>
                 <url>zendesk</url>
                 <title>Support</title>

--- a/src/app/design/frontend/base/default/layout/zendesk.xml
+++ b/src/app/design/frontend/base/default/layout/zendesk.xml
@@ -19,10 +19,36 @@
 <layout>
     <default>
         <reference name="footer_links">
-            <action method="addLink" translate="label title" module="contacts" ifconfig="zendesk/features/footer_link_enabled"><label>Support</label><url>zendesk</url><title>Support</title><prepare>true</prepare></action>
+            <action method="addLink" translate="label title" module="contacts"
+                    ifconfig="zendesk/features/footer_link_enabled">
+                <label>Support</label>
+                <url>zendesk</url>
+                <title>Support</title>
+                <prepare>true</prepare>
+            </action>
         </reference>
         <reference name="before_body_end">
             <block type="zendesk/supporttab" name="zendesk_support_tab"/>
         </reference>
     </default>
+
+    <customer_account>
+        <reference name="customer_account_navigation">
+            <action method="addLink" ifconfig="zendesk/features/customer_tickets" translate="label" module="zendesk">
+                <name>customertickets</name>
+                <path>zendesk/customer_tickets/index</path>
+                <label>My Tickets</label>
+            </action>
+        </reference>
+    </customer_account>
+
+    <zendesk_customer_tickets_index>
+        <update handle="customer_account"/>
+        <reference name="my.account.wrapper">
+            <block type="zendesk/customer_tickets" name="zendesk.customer.tickets">
+                <block type="zendesk/customer_tickets_list" name="zendesk.customer.tickets.list" />
+            </block>
+        </reference>
+    </zendesk_customer_tickets_index>
+
 </layout>

--- a/src/app/design/frontend/base/default/template/zendesk/customer/tickets.phtml
+++ b/src/app/design/frontend/base/default/template/zendesk/customer/tickets.phtml
@@ -24,7 +24,7 @@
 
 <div>
     <div class="page-title">
-        <h1><?php echo $this->__('My Orders') ?></h1>
+        <h1><?php echo $this->__('My Tickets') ?></h1>
     </div>
 
     <div><?php echo $this->getChildHtml(); ?></div>

--- a/src/app/design/frontend/base/default/template/zendesk/customer/tickets.phtml
+++ b/src/app/design/frontend/base/default/template/zendesk/customer/tickets.phtml
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Copyright 2014 Zendesk.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+?>
+
+<?php
+
+    if(!Mage::getStoreConfig('zendesk/features/customer_tickets')) {
+        return;
+    }
+?>
+
+<div></div>

--- a/src/app/design/frontend/base/default/template/zendesk/customer/tickets.phtml
+++ b/src/app/design/frontend/base/default/template/zendesk/customer/tickets.phtml
@@ -17,10 +17,15 @@
 ?>
 
 <?php
-
     if(!Mage::getStoreConfig('zendesk/features/customer_tickets')) {
         return;
     }
 ?>
 
-<div></div>
+<div>
+    <div class="page-title">
+        <h1><?php echo $this->__('My Orders') ?></h1>
+    </div>
+
+    <div><?php echo $this->getChildHtml(); ?></div>
+</div>

--- a/src/app/design/frontend/base/default/template/zendesk/customer/tickets/list.phtml
+++ b/src/app/design/frontend/base/default/template/zendesk/customer/tickets/list.phtml
@@ -28,7 +28,6 @@
                 <table cellspacing="0" class="data-table">
                     <thead>
                     <tr>
-                        <th><?php echo Mage::helper('zendesk')->__('Priority') ?></th>
                         <th><?php echo Mage::helper('zendesk')->__('Subject') ?></th>
                         <th><?php echo Mage::helper('zendesk')->__('Requested') ?></th>
                         <th><?php echo Mage::helper('zendesk')->__('Updated') ?></th>
@@ -39,7 +38,6 @@
                     <?php foreach($tickets as $ticket): ?>
                         <?php $t = Mage::getModel('zendesk/api_tickets')->get($ticket['id'], true); ?>
                         <tr class="border">
-                            <td><?php echo ucwords($ticket['priority']); ?></td>
                             <td><a href="<?php echo Mage::helper('zendesk')->getUrl('ticket', $ticket['id']); ?>" target="_blank"><?php echo $ticket['subject']; ?></a></td>
                             <td><?php echo Mage::helper('core')->formatDate($ticket['created_at'], Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true); ?></td>
                             <td><?php echo Mage::helper('core')->formatDate($ticket['updated_at'], Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true); ?></td>

--- a/src/app/design/frontend/base/default/template/zendesk/customer/tickets/list.phtml
+++ b/src/app/design/frontend/base/default/template/zendesk/customer/tickets/list.phtml
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright 2012 Zendesk.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+?>
+
+<div></div>

--- a/src/app/design/frontend/base/default/template/zendesk/customer/tickets/list.phtml
+++ b/src/app/design/frontend/base/default/template/zendesk/customer/tickets/list.phtml
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2012 Zendesk.
+ * Copyright 2014 Zendesk.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,4 +16,41 @@
  */
 ?>
 
-<div></div>
+<?php $tickets = $this->getList(); ?>
+
+<?php if($tickets): ?>
+    <div class="entry-edit">
+        <div class="entry-edit-head">
+            <h4 class="icon-head head-account"><?php echo Mage::helper('zendesk')->__('Support Tickets') ?></h4>
+        </div>
+        <div class="grid">
+            <div class="hor-scroll">
+                <table cellspacing="0" class="data-table">
+                    <thead>
+                    <tr>
+                        <th><?php echo Mage::helper('zendesk')->__('Priority') ?></th>
+                        <th><?php echo Mage::helper('zendesk')->__('Subject') ?></th>
+                        <th><?php echo Mage::helper('zendesk')->__('Requested') ?></th>
+                        <th><?php echo Mage::helper('zendesk')->__('Updated') ?></th>
+                        <th><?php echo Mage::helper('zendesk')->__('Status') ?></th>
+                    </tr>
+                    </thead>
+                    <tbody class="odd">
+                    <?php foreach($tickets as $ticket): ?>
+                        <?php $t = Mage::getModel('zendesk/api_tickets')->get($ticket['id'], true); ?>
+                        <tr class="border">
+                            <td><?php echo ucwords($ticket['priority']); ?></td>
+                            <td><a href="<?php echo Mage::helper('zendesk')->getUrl('ticket', $ticket['id']); ?>" target="_blank"><?php echo $ticket['subject']; ?></a></td>
+                            <td><?php echo Mage::helper('core')->formatDate($ticket['created_at'], Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true); ?></td>
+                            <td><?php echo Mage::helper('core')->formatDate($ticket['updated_at'], Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true); ?></td>
+                            <td><?php echo ucwords($ticket['status']); ?></td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <?php else: ?>
+    <div><?php echo $this->__('You dont have any tickets'); ?></div>
+<?php endif; ?>


### PR DESCRIPTION
Creates new section within My Account so Customers are able to see their tickets.
By clicking in the new item "My Tickets" -located in the account navigation- a table will be populated with tickets from that particular Customer.

Rows will have this info from each ticket:
- subject
- status
- created at
- modified at

Ticket's subject has link to the Zendesk ticket, so Customer can easily access.
Block that renders the grid will cache for 5m to improve loading time.
