### PR TITLE
Fixed frontend template links

### DIFF
--- a/modman
+++ b/modman
@@ -2,6 +2,7 @@ src/app/code/community/Zendesk/Zendesk                            app/code/commu
 src/app/design/adminhtml/default/default/layout/zendesk.xml       app/design/adminhtml/default/default/layout/zendesk.xml
 src/app/design/adminhtml/default/default/template/zendesk         app/design/adminhtml/default/default/template/zendesk
 src/app/design/frontend/base/default/layout/zendesk.xml           app/design/frontend/base/default/layout/zendesk.xml
+src/app/design/frontend/base/default/template/zendesk             app/design/frontend/base/default/template/zendesk
 src/app/etc/modules/Zendesk_Zendesk.xml                           app/etc/modules/Zendesk_Zendesk.xml
 src/app/locale/de_DE/Zendesk_Zendesk.csv                          app/locale/de_DE/Zendesk_Zendesk.csv
 src/app/locale/en_US/Zendesk_Zendesk.csv                          app/locale/en_US/Zendesk_Zendesk.csv


### PR DESCRIPTION
Added a missing line to modman file so frontend templates are linked in correctly.
