### PR TITLE
Use the custom URL for the admin store if one exists

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
@@ -109,6 +109,9 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
 
     public function getOrderDetail($order)
     {
+        // if the admin site has a custom URL, use it
+        $urlModel = Mage::getModel('adminhtml/url')->setStore('admin');
+
         $orderInfo = array(
             'id' => $order->getIncrementId(),
             'status' => $order->getStatus(),
@@ -124,7 +127,7 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
             'total' => $order->getGrandTotal(),
             'currency' => $order->getOrderCurrencyCode(),
             'items' => array(),
-            'admin_url' => Mage::helper('adminhtml')->getUrl('adminhtml/sales_order/view', array('order_id' => $order->getId())),
+            'admin_url' => $urlModel->getUrl('adminhtml/sales_order/view', array('order_id' => $order->getId())),
         );
 
         foreach($order->getItemsCollection(array(), true) as $item) {

--- a/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
@@ -135,6 +135,9 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
         // Try to load a corresponding customer object for the provided email address
         $customer = Mage::helper('zendesk')->loadCustomer($email);
 
+        // if the admin site has a custom URL, use it
+        $urlModel = Mage::getModel('adminhtml/url')->setStore('admin');
+
         if($customer && $customer->getId()) {
             $info = array(
                 'guest' => false,
@@ -142,7 +145,7 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
                 'name' => $customer->getName(),
                 'email' => $customer->getEmail(),
                 'active' => (bool)$customer->getIsActive(),
-                'admin_url' => Mage::helper('adminhtml')->getUrl('adminhtml/zendesk/redirect', array('id' => $customer->getId(), 'type' => 'customer')),
+                'admin_url' => $urlModel->getUrl('adminhtml/zendesk/redirect', array('id' => $customer->getId(), 'type' => 'customer')),
                 'created' => $customer->getCreatedAt(),
                 'dob' => $customer->getDob(),
                 'addresses' => array(),


### PR DESCRIPTION
When returning links to customers and to orders, use the URL for the admin store. It might have been customized. For more info, in Magento admin go to System -> Configuration -> Admin -> Admin Base URL.
