### PR TITLE
Redirect to login page if trying to access tickets list in customer account while logged out

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/controllers/Customer/TicketsController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Customer/TicketsController.php
@@ -18,6 +18,14 @@
 class Zendesk_Zendesk_Customer_TicketsController extends Mage_Core_Controller_Front_Action
 {
 
+    public function preDispatch()
+    {
+        parent::preDispatch();
+        if (!Mage::getSingleton('customer/session')->isLoggedIn()) {
+            $this->_redirectUrl(Mage::helper('customer')->getAccountUrl());
+        }
+    }
+
     /**
      * Display data
      */


### PR DESCRIPTION
This solves an issue where accessing <base_url>/zendesk/customer_tickets/index causes an InvalidArgumentException from Zendesk_Zendesk_Model_Api_Tickets::forRequester to bubble up to the user.  Simply wrapping calls to forRequester() would not be enough, as the user would still be taken to the My Account section while they are not logged in, and that's weird.
