### PR TITLE
Option to create tickets from Magento dashboard with internal notes

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Create/Edit/Form.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Create/Edit/Form.php
@@ -103,6 +103,17 @@ class Zendesk_Zendesk_Block_Adminhtml_Create_Edit_form extends Mage_Adminhtml_Bl
             )
         ));
         
+        $fieldset->addField('visibility', 'select', array(
+            'name'     => 'visibility',
+            'label'    => Mage::helper('zendesk')->__('Visibility'),
+            'title'    => Mage::helper('zendesk')->__('Visibility'),
+            'required' => false,
+            'values'   => array(
+                array('label' => 'Public', 'value' => 'true'),
+                array('label' => 'Internal', 'value' => 'false'),
+            )
+        ));
+        
         $fieldset->addField('order', 'text', array(
             'name'     => 'order',
             'label'    => Mage::helper('zendesk')->__('Order number'),

--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -246,6 +246,7 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
                         'status' => $data['status'],
                         'priority' => $data['priority'],
                         'comment' => array(
+                            'public' => $data['visibility'],
                             'value' => $data['description']
                         )
                     )


### PR DESCRIPTION
This adds a field in the Magento "Create Ticket" form, and based on this sets the comment as public comment or internal note when submitting the ticket through the API.

The fix is rather simple, but It's always best to have it inside the official module for the sake of upgrades.

Background: A customer of ours requested the ability to create tickets from the Magento dashboard with internal notes instead of public comments, mainly to be able to make a "quick issue with some internal notes" from Magento, then following up later on from Zendesk. 
