### PR TITLE
Set raw body also for PUT requests

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/Abstract.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/Abstract.php
@@ -51,7 +51,7 @@ class Zendesk_Zendesk_Model_Api_Abstract extends Mage_Core_Model_Abstract
             Mage::getStoreConfig('zendesk/general/password')
         );
 
-        if($method == 'POST') {
+        if($method == 'POST' || $method == 'PUT') {
             $client->setRawData(json_encode($data), 'application/json');
         }
 


### PR DESCRIPTION
When extending this module for making updates with PUT requests, the abstract `_call` method does not set the raw request body. This update will allow it to do that.
