### PR TITLE
Force admin_url to be admin store url

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
@@ -127,7 +127,7 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
             'total' => $order->getGrandTotal(),
             'currency' => $order->getOrderCurrencyCode(),
             'items' => array(),
-            'admin_url' => $urlModel->getUrl('adminhtml/sales_order/view', array('order_id' => $order->getId())),
+            'admin_url' => $urlModel->getUrl('adminhtml/sales_order/view', array('order_id' => $order->getId(), '_store' => Mage_Core_Model_App::ADMIN_STORE_ID)),
         );
 
         foreach($order->getItemsCollection(array(), true) as $item) {

--- a/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
@@ -160,7 +160,7 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
                 'name' => $customer->getName(),
                 'email' => $customer->getEmail(),
                 'active' => (bool)$customer->getIsActive(),
-                'admin_url' => $urlModel->getUrl('adminhtml/zendesk/redirect', array('id' => $customer->getId(), 'type' => 'customer')),
+                'admin_url' => $urlModel->getUrl('adminhtml/zendesk/redirect', array('id' => $customer->getId(), 'type' => 'customer', '_store' => Mage_Core_Model_App::ADMIN_STORE_ID)),
                 'created' => $customer->getCreatedAt(),
                 'dob' => $customer->getDob(),
                 'addresses' => array(),


### PR DESCRIPTION
It is possible to have a different domain for the admin panel. Where normally you'd have mysite.com and mysite.com/admin, you could change the admin store to be at admin.mysite.com/admin. This change will force it to return the admin version every time. The Mage_Core_Model_App::ADMIN_STORE_ID constant is 0.
