### PR TITLE
[CE-707] Replace Feedback Tab with Web Widget

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/webWidget.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/webWidget.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2012 Zendesk.
+ * Copyright 2015 Zendesk.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,14 @@
  * limitations under the License.
  */
 
-class Zendesk_Zendesk_Block_Supporttab extends Mage_Core_Block_Template
+class Zendesk_Zendesk_Block_WebWidget extends Mage_Core_Block_Template
 {
     protected function _toHtml()
     {
-        if(!Mage::getStoreConfig('zendesk/frontend_features/feedback_tab_code_active')) {
+        if(!Mage::getStoreConfig('zendesk/frontend_features/web_widget_code_active')) {
             return '';
         }
 
-        return Mage::getStoreConfig('zendesk/frontend_features/feedback_tab_code');
+        return Mage::getStoreConfig('zendesk/frontend_features/web_widget_code_snippet');
     }
 }

--- a/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
@@ -367,12 +367,12 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
             }
         }
 
-        if(isset($data['feedback_tab'])) {
-            $configUpdates['zendesk/frontend_features/feedback_tab_code_active'] = ($data['feedback_tab'] === 'true');
+        if(isset($data['web_widget_code_active'])) {
+            $configUpdates['zendesk/frontend_features/web_widget_code_active'] = ($data['web_widget_code_active'] === 'true');
         }
 
-        if(isset($data['feedback_tab_html'])) {
-            $configUpdates['zendesk/frontend_features/feedback_tab_code'] = $data['feedback_tab_html'];
+        if(isset($data['web_widget_code_snippet'])) {
+            $configUpdates['zendesk/frontend_features/web_widget_code_snippet'] = $data['web_widget_code_snippet'];
         }
 
 

--- a/src/app/code/community/Zendesk/Zendesk/etc/system.xml
+++ b/src/app/code/community/Zendesk/Zendesk/etc/system.xml
@@ -179,7 +179,7 @@
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>
-                    <fields> 
+                    <fields>
                         <contact_us translate="label">
                             <label>Create tickets from Contact Us form</label>
                             <frontend_type>select</frontend_type>
@@ -189,38 +189,25 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </contact_us>
-                        <feedback_tab_code_active translate="label">
-                            <label>Code to display Feedback Tab</label>
+                        <web_widget_code_active translate="label">
+                            <label>Include Web Widget</label>
                             <frontend_type>select</frontend_type>
                             <source_model>adminhtml/system_config_source_yesno</source_model>
                             <sort_order>6</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </feedback_tab_code_active>
-                        <feedback_tab_code>
-                            <frontend_type>textarea</frontend_type>
+                        </web_widget_code_active>
+                        <web_widget_customise translate="label value">
+                            <label></label>
+                            <frontend_model>zendesk/adminhtml_config_link</frontend_model>
+                            <destination><![CDATA[agent/admin/widget]]></destination>
+                            <value>Customize Web Widget</value>
                             <sort_order>7</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                            <depends>
-                                <feedback_tab_code_active>1</feedback_tab_code_active>
-                            </depends>
-                        </feedback_tab_code>
-                        <feedback_tab_customise translate="label value">
-                            <label></label>
-                            <frontend_model>zendesk/adminhtml_config_link</frontend_model>
-                            <destination><![CDATA[account/dropboxes/new]]></destination>
-                            <value>Customize Feedback Tab</value>
-                            <sort_order>8</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <depends>
-                                <feedback_tab_code_active>1</feedback_tab_code_active>
-                            </depends>
-                        </feedback_tab_customise>
+                        </web_widget_customise>
                         <footer_link_enabled translate="label">
                             <label>Display link to Zendesk in Magento footer</label>
                             <frontend_type>select</frontend_type>
@@ -269,7 +256,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </show_on_order>   
+                        </show_on_order>
                         <show_on_dashboard translate="label">
                             <label>Show support tickets on admin dashboard</label>
                             <frontend_type>select</frontend_type>
@@ -287,7 +274,7 @@
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>0</show_in_store>
-                        </show_all> 
+                        </show_all>
                         <default_sort translate="label">
                             <label>Default Sort Order</label>
                             <frontend_type>select</frontend_type>
@@ -442,16 +429,16 @@
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
                         </voice>
-                        <feedback_tab translate="label value">
-                            <label>Feedback Tab</label>
+                        <web_widget translate="label value">
+                            <label>Web Widget</label>
                             <frontend_model>zendesk/adminhtml_config_link</frontend_model>
-                            <destination><![CDATA[account/dropboxes/new]]></destination>
+                            <destination><![CDATA[agent/admin/widget]]></destination>
                             <value>Configure</value>
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>
-                        </feedback_tab>
+                        </web_widget>
                         <api translate="label value">
                             <label>API</label>
                             <frontend_model>zendesk/adminhtml_config_link</frontend_model>

--- a/src/app/design/frontend/base/default/layout/zendesk.xml
+++ b/src/app/design/frontend/base/default/layout/zendesk.xml
@@ -27,7 +27,7 @@
             </action>
         </reference>
         <reference name="before_body_end">
-            <block type="zendesk/supporttab" name="zendesk_support_tab"/>
+            <block type="zendesk/webWidget" name="zendesk_web_widget"/>
         </reference>
     </default>
 


### PR DESCRIPTION
:snake:

Version 2.0 won't be bundling the Feedback Tab but the Web Widget. This PR applies most of the changes to  the settings and layout.
- `ApiController.php` won't parse the Feedback Tab paramenters coming from the Provisioning install script, but will parse the Web Widget parameters.
- Update `system.xml` to reflect the changes on the settings page.
- Drop the Supporttab layout and add the Web Widget one.

/cc @zendesk/taipan
### References
- Jira link: https://zendesk.atlassian.net/browse/CE-707
### Risks
- None
