### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,8 @@ The API can be enabled in the Zendesk settings page in the Magento admin panel. 
 
 ### Single Sign-on (SSO)
 
-* Admins & Agents
-
-  Remote login URL: http://your_site_base_url/admin/zendesk/authenticate
-  Remote logout URL: http://your_site_base_url/admin/zendesk/logout
-
-* End-user
-
-  Remote login URL: http://your_site_base_url/zendesk/sso/login
-  Remote logout URL: http://your_site_base_url/zendesk/sso/logout
+  **Remote login URL** http://your_site_base_url/zendesk/sso/login
+  **Remote logout URL** http://your_site_base_url/zendesk/sso/logout
 
 ### Responses
 


### PR DESCRIPTION
Zendesk only supports a single pair of SSO URLs. 

It's up to the Magento Extension upon getting a request to build a login request to figure out if the email used is tied in Zendesk to either an agent/admin or an end-user & redirect accordingly.

CC @jwswj @maxmi @mmolina
