### PR TITLE
Corrected new ticket link

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Customer/Tickets.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Customer/Tickets.php
@@ -25,7 +25,7 @@ class Zendesk_Zendesk_Block_Customer_Tickets extends Mage_Core_Block_Template
     
     public function getSubmitAction() {
         if (!$return_url = Mage::getStoreConfig('zendesk/sso_frontend/new')) {
-            $return_url = "http://".Mage::getStoreConfig('zendesk/general/domain')."/requests/new";
+            $return_url = "http://".Mage::getStoreConfig('zendesk/general/domain')."/hc/requests/new";
         }
         $url = Mage::helper('adminhtml')->getUrl('*/sso/login', array("return_url" => Mage::helper('core')->urlEncode($return_url)));
 


### PR DESCRIPTION
Customers getting an oops page for the default new ticket link which points to https://domain.zendesk.com/requests/new. 

Changed to https://domain.zendesk.com/hc/requests/new

/cc @zendesk/mintegrations 
