### PR TITLE
Mmolina/update widget code observer

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
@@ -101,9 +101,8 @@ class Zendesk_Zendesk_Model_Observer
         // If the zendesk domain is not found in the web widget snippet (wrapped with quotes), generate it again
         $zDomain = Mage::getStoreConfig('zendesk/general/domain', $storeCode);
         $widgetSnippet = Mage::getStoreConfig('zendesk/frontend_features/web_widget_code_snippet', $storeCode);
-        $escapedDomain = str_replace('.', '\.', $zDomain);
-        $pattern = "/['\"]{$escapedDomain}['\"]/isu";
-        if(preg_match($pattern, $widgetSnippet) < 1) {
+        // Case insensitive search with single and double quotes, still better performance than 1 regexp search
+        if(stripos($widgetSnippet, "'{$zDomain}'") === false && stripos($widgetSnippet, '"'.$zDomain.'"') === false) {
             $webWidgetSnippet=<<<EOJS
 <!-- Start of Zendesk Widget script -->
 <script>/*<![CDATA[*/window.zEmbed||function(e,t){var n,o,d,i,s,a=[],r=document.createElement("iframe");window.zEmbed=function(){a.push(arguments)},window.zE=window.zE||window.zEmbed,r.src="javascript:false",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="display: none",d=document.getElementsByTagName("script"),d=d[d.length-1],d.parentNode.insertBefore(r,d),i=r.contentWindow,s=i.document;try{o=s}catch(c){n=document.domain,r.src='javascript:var d=document.open();d.domain="'+n+'";void(0);',o=s}o.open()._l=function(){var o=this.createElement("script");n&&(this.domain=n),o.id="js-iframe-async",o.src=e,this.t=+new Date,this.zendeskHost=t,this.zEQueue=a,this.body.appendChild(o)},o.write('<body onload="document._l();">'),o.close()}("//assets.zendesk.com/embeddable_framework/main.js","{$zDomain}");/*]]>*/</script>

--- a/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
@@ -97,6 +97,21 @@ class Zendesk_Zendesk_Model_Observer
                 Mage::getModel('core/config')->saveConfig('contacts/email/recipient_email', $oldEmail, $scope, $scopeId);
             }
         }
+
+        // If the zendesk domain is not found in the web widget snippet (wrapped with quotes), generate it again
+        $zDomain = Mage::getStoreConfig('zendesk/general/domain', $storeCode);
+        $widgetSnippet = Mage::getStoreConfig('zendesk/frontend_features/web_widget_code_snippet', $storeCode);
+        $escapedDomain = str_replace('.', '\.', $zDomain);
+        $pattern = "/['\"]{$escapedDomain}['\"]/isu";
+        if(preg_match($pattern, $widgetSnippet) < 1) {
+            $webWidgetSnippet=<<<EOJS
+<!-- Start of Zendesk Widget script -->
+<script>/*<![CDATA[*/window.zEmbed||function(e,t){var n,o,d,i,s,a=[],r=document.createElement("iframe");window.zEmbed=function(){a.push(arguments)},window.zE=window.zE||window.zEmbed,r.src="javascript:false",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="display: none",d=document.getElementsByTagName("script"),d=d[d.length-1],d.parentNode.insertBefore(r,d),i=r.contentWindow,s=i.document;try{o=s}catch(c){n=document.domain,r.src='javascript:var d=document.open();d.domain="'+n+'";void(0);',o=s}o.open()._l=function(){var o=this.createElement("script");n&&(this.domain=n),o.id="js-iframe-async",o.src=e,this.t=+new Date,this.zendeskHost=t,this.zEQueue=a,this.body.appendChild(o)},o.write('<body onload="document._l();">'),o.close()}("//assets.zendesk.com/embeddable_framework/main.js","{$zDomain}");/*]]>*/</script>
+<!-- End of Zendesk Widget script -->
+EOJS;
+
+            Mage::getModel('core/config')->saveConfig('zendesk/frontend_features/web_widget_code_snippet', $webWidgetSnippet);
+        }
     }
 
     public function addTicketButton(Varien_Event_Observer $event)


### PR DESCRIPTION
:snake:

We are not displaying users the Web Widget snippet on the settings page, so we need to put in place a mechanism to update the snippet for them in background if the domain changes.

This PR instruments that in the observer method executed when the zendesk settings are updated: If the account Zendesk domain is not found in the Web Widget snippet, it'll be generated again.

Merging this into the feature branch, which I'm testing at the moment.

/cc @zendesk/taipan @jwswj 
### References
- Jira link: 
### Risks
- None
