### PR TITLE
Set array_filter response to a variable , for #50

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Grids.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Grids.php
@@ -65,15 +65,20 @@ class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Grids extends Mage_Adminhtml_Blo
             } catch (Exception $ex) {
                 $allTicketView = array();
             }
-                
+
+            // Loop through each view ID as per config
             foreach($viewsIds as $viewId) {
-                $view = array_shift(array_filter($allTicketView, function($view) use($viewId) {
-                    return $view['id'] === (int) $viewId;
-                }));
-                
-                $count = array_shift(array_filter($ticketsCounts['view_counts'], function($view) use($viewId) {
+                // Searches for the view's details by matching all views retrieved from the api to the current view id
+                $view = array_filter($allTicketView, function($ticketView) use($viewId) {
+                    return $ticketView['id'] === (int) $viewId;
+                });
+                // Return only the first value (usually returns just 1)
+                $view = array_shift($view);
+
+                $count = array_filter($ticketsCounts['view_counts'], function($view) use($viewId) {
                     return $view['view_id'] === (int) $viewId;
-                }));
+                });
+                $count = array_shift($count);
                 
                 if($count['value']) {
                     $label = $view['title'] . ' (' . $count['value'] . ')';

--- a/src/app/code/community/Zendesk/Zendesk/Model/Resource/Tickets/Collection.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Resource/Tickets/Collection.php
@@ -133,17 +133,21 @@ class Zendesk_Zendesk_Model_Resource_Tickets_Collection extends Varien_Data_Coll
     public function getCollectionFromView($viewId, array $params = array()) {
         $view = Mage::getModel('zendesk/api_views')->execute($viewId, $params);
         
-        foreach ($view['rows'] as $row) {
-            $ticket = array_merge($row, $row['ticket']);
-            
-            $this->appendParamsWithoutIdPostfix($ticket, array('requester', 'assignee', 'group'));
-            
-            $obj = new Varien_Object();
-            $obj->setData($ticket);
-            $this->addItem($obj);
+        // Loop through the rows if the view is found and active
+        if (!empty($view)) {
+            foreach ($view['rows'] as $row) {
+                $ticket = array_merge($row, $row['ticket']);
+                
+                $this->appendParamsWithoutIdPostfix($ticket, array('requester', 'assignee', 'group'));
+                
+                $obj = new Varien_Object();
+                $obj->setData($ticket);
+                $this->addItem($obj);
+            }
+
+            $this->_viewColumns = $view['columns'];
         }
         
-        $this->_viewColumns = $view['columns'];
 
         $this->setPageSize($params['per_page']);
         $this->setCurPage($params['page']);
@@ -168,7 +172,7 @@ class Zendesk_Zendesk_Model_Resource_Tickets_Collection extends Varien_Data_Coll
     
     public function getColumnsForView() {
         $excludedColumns = static::$_excludedColumns;
-        
+
         return array_filter($this->_viewColumns, function($column) use($excludedColumns) {
             return ! in_array($column['id'], $excludedColumns);
         });


### PR DESCRIPTION
Separates the array_shift call from the array_filter to workaround the strict notice. 

/cc @jwswj @miogalang @mmolina 
### References
- Jira link: https://zendesk.atlassian.net/browse/MI-32
### Risks
- None
- QA notes: To be able to reproduce this, at least 1 view must be chosen under Zendesk > Configuration ("Views to show on dashboards")
