### PR TITLE
Jose/fix dashboard error

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Grids.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Grids.php
@@ -34,6 +34,8 @@ class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Grids extends Mage_Adminhtml_Blo
             return parent::_prepareLayout();
         }
 
+        Mage::helper('zendesk')->storeDependenciesInCachedRegistry();
+
         //check if module is setted up
         $configured     = (bool) Mage::getStoreConfig('zendesk/general/domain');
         $viewsIds       = Mage::getStoreConfig('zendesk/backend_features/show_views') ? Mage::helper('zendesk')->getChosenViews() : array(); 

--- a/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
@@ -370,4 +370,23 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
         }
     }
     
+    public function storeDependenciesInCachedRegistry() {
+        $cache = Mage::app()->getCache();
+        
+        if( $cache->load('zendesk_users') === false) {
+            $users = serialize( Mage::getModel('zendesk/api_users')->all() );
+            $cache->save($users, 'zendesk_users', array('zendesk', 'zendesk_users'), 300);
+        }
+        
+        if( $cache->load('zendesk_groups') === false) {
+            $groups = serialize( Mage::getModel('zendesk/api_groups')->all() );
+            $cache->save($groups, 'zendesk_groups', array('zendesk', 'zendesk_groups'), 1200);
+        }
+        
+        $users  = unserialize( $cache->load('zendesk_users') );
+        $groups = unserialize( $cache->load('zendesk_groups') );
+        
+        Mage::register('zendesk_users', $users);
+        Mage::register('zendesk_groups', $groups);
+    }
 }

--- a/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
@@ -372,21 +372,25 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
     
     public function storeDependenciesInCachedRegistry() {
         $cache = Mage::app()->getCache();
-        
-        if( $cache->load('zendesk_users') === false) {
-            $users = serialize( Mage::getModel('zendesk/api_users')->all() );
-            $cache->save($users, 'zendesk_users', array('zendesk', 'zendesk_users'), 300);
+
+        if (null == Mage::registry('zendesk_users')) {
+            if( $cache->load('zendesk_users') === false) {
+                $users = serialize( Mage::getModel('zendesk/api_users')->all() );
+                $cache->save($users, 'zendesk_users', array('zendesk', 'zendesk_users'), 300);
+            }
+
+            $users  = unserialize( $cache->load('zendesk_users') );
+            Mage::register('zendesk_users', $users);
         }
-        
-        if( $cache->load('zendesk_groups') === false) {
-            $groups = serialize( Mage::getModel('zendesk/api_groups')->all() );
-            $cache->save($groups, 'zendesk_groups', array('zendesk', 'zendesk_groups'), 1200);
+
+        if (null == Mage::registry('zendesk_groups')) {
+            if( $cache->load('zendesk_groups') === false) {
+                $groups = serialize( Mage::getModel('zendesk/api_groups')->all() );
+                $cache->save($groups, 'zendesk_groups', array('zendesk', 'zendesk_groups'), 1200);
+            }
+            
+            $groups = unserialize( $cache->load('zendesk_groups') );
+            Mage::register('zendesk_groups', $groups);
         }
-        
-        $users  = unserialize( $cache->load('zendesk_users') );
-        $groups = unserialize( $cache->load('zendesk_groups') );
-        
-        Mage::register('zendesk_users', $users);
-        Mage::register('zendesk_groups', $groups);
     }
 }

--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -35,8 +35,8 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
             $this->_redirect('adminhtml/dashboard');
             return;
         }
-        
-        $this->storeDependenciesInCachedRegistry();
+
+        Mage::helper('zendesk')->storeDependenciesInCachedRegistry();
         
         $this->_title($this->__('Zendesk Dashboard'));
         $this->loadLayout();
@@ -629,7 +629,7 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
         $isAjax = Mage::app()->getRequest()->isAjax();
         
         if ($isAjax) {
-            $this->storeDependenciesInCachedRegistry();
+            Mage::helper('zendesk')->storeDependenciesInCachedRegistry();
             $this->getResponse()->setBody($this->getLayout()->createBlock('zendesk/adminhtml_dashboard_tab_tickets_grid_all')->toHtml());
         }
     }
@@ -638,7 +638,7 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
         $isAjax = Mage::app()->getRequest()->isAjax();
 
         if ($isAjax) {
-            $this->storeDependenciesInCachedRegistry();
+            Mage::helper('zendesk')->storeDependenciesInCachedRegistry();
             $viewId = (int) $this->getRequest()->getParam('viewid');
             Mage::register('zendesk_tickets_view', $viewId);
             
@@ -647,23 +647,7 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
     }
     
     protected function storeDependenciesInCachedRegistry() {
-        $cache = Mage::app()->getCache();
         
-        if( $cache->load('zendesk_users') === false) {
-            $users = serialize( Mage::getModel('zendesk/api_users')->all() );
-            $cache->save($users, 'zendesk_users', array('zendesk', 'zendesk_users'), 300);
-        }
-        
-        if( $cache->load('zendesk_groups') === false) {
-            $groups = serialize( Mage::getModel('zendesk/api_groups')->all() );
-            $cache->save($groups, 'zendesk_groups', array('zendesk', 'zendesk_groups'), 1200);
-        }
-        
-        $users  = unserialize( $cache->load('zendesk_users') );
-        $groups = unserialize( $cache->load('zendesk_groups') );
-        
-        Mage::register('zendesk_users', $users);
-        Mage::register('zendesk_groups', $groups);
     }
     
     protected function getMassActionResponse($response, $ids, $message = '%d out of %d ticket(s) were updated.')

--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -646,10 +646,6 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
         }
     }
     
-    protected function storeDependenciesInCachedRegistry() {
-        
-    }
-    
     protected function getMassActionResponse($response, $ids, $message = '%d out of %d ticket(s) were updated.')
     {
         if (isset($response['job_status']) && isset($response['job_status']['url'])) {


### PR DESCRIPTION
Fixes the following bug:
1. Zendesk configuration - Show "All" tab on dashboard - must be set to "yes"
2. Go to the Magento Admin dashboard. 
3. PHP errors are displayed and the page is not rendered.

This PR moves Zendesk_Zendesk_Adminhtml_ZendeskController::storeDependenciesInCachedRegistry() to a helper class, making it accessible to other classes. 

The zendesk grid on the magento dashboard depends on Mage::registry('zendesk_users') to have an array value. Apparently this isn't being set on the dashboard, since storeDependenciesInCachedRegistry() is exclusively on the controller class.

/cc @jwswj @miogalang @mmolina 
### References
- Support link: https://support.zendesk.com/agent/tickets/1060080
### Risks
- Low
