### PR TITLE
Be sure the widget is active

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
@@ -111,6 +111,8 @@ EOJS;
 
             Mage::getModel('core/config')->saveConfig('zendesk/frontend_features/web_widget_code_active', 1);
             Mage::getModel('core/config')->saveConfig('zendesk/frontend_features/web_widget_code_snippet', $webWidgetSnippet);
+        } elseif (empty($zDomain)) {
+            Mage::getModel('core/config')->saveConfig('zendesk/frontend_features/web_widget_code_snippet', '');
         }
     }
 

--- a/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
@@ -102,7 +102,7 @@ class Zendesk_Zendesk_Model_Observer
         $zDomain = Mage::getStoreConfig('zendesk/general/domain', $storeCode);
         $widgetSnippet = Mage::getStoreConfig('zendesk/frontend_features/web_widget_code_snippet', $storeCode);
         // Case insensitive search with single and double quotes, still better performance than 1 regexp search
-        if(stripos($widgetSnippet, "'{$zDomain}'") === false && stripos($widgetSnippet, '"'.$zDomain.'"') === false) {
+        if($zDomain && stripos($widgetSnippet, "'{$zDomain}'") === false && stripos($widgetSnippet, '"'.$zDomain.'"') === false) {
             $webWidgetSnippet=<<<EOJS
 <!-- Start of Zendesk Widget script -->
 <script>/*<![CDATA[*/window.zEmbed||function(e,t){var n,o,d,i,s,a=[],r=document.createElement("iframe");window.zEmbed=function(){a.push(arguments)},window.zE=window.zE||window.zEmbed,r.src="javascript:false",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="display: none",d=document.getElementsByTagName("script"),d=d[d.length-1],d.parentNode.insertBefore(r,d),i=r.contentWindow,s=i.document;try{o=s}catch(c){n=document.domain,r.src='javascript:var d=document.open();d.domain="'+n+'";void(0);',o=s}o.open()._l=function(){var o=this.createElement("script");n&&(this.domain=n),o.id="js-iframe-async",o.src=e,this.t=+new Date,this.zendeskHost=t,this.zEQueue=a,this.body.appendChild(o)},o.write('<body onload="document._l();">'),o.close()}("//assets.zendesk.com/embeddable_framework/main.js","{$zDomain}");/*]]>*/</script>

--- a/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
@@ -109,6 +109,7 @@ class Zendesk_Zendesk_Model_Observer
 <!-- End of Zendesk Widget script -->
 EOJS;
 
+            Mage::getModel('core/config')->saveConfig('zendesk/frontend_features/web_widget_code_active', 1);
             Mage::getModel('core/config')->saveConfig('zendesk/frontend_features/web_widget_code_snippet', $webWidgetSnippet);
         }
     }


### PR DESCRIPTION
:snake:

I just discovered an edge case:
- A user installs the extension from scratch
- There is no domain set, so the web widget is not active, and the snippet can't be created
- Some time after that the user setup the domain
- The snippet is now updated, but the widget was still off

This fix that: if the snippet is updated, we enable the widget (even if it may have been active already)

/cc @zendesk/taipan @miogalang @joseconsador 
