### PR TITLE
Change route used in getUrl call

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Grids.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Grids.php
@@ -43,7 +43,7 @@ class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Grids extends Mage_Adminhtml_Blo
         if( Mage::getStoreConfig('zendesk/backend_features/show_all') AND $configured) {
             $all = array(
                 'class' => 'ajax',
-                'url'   => $this->getUrl('zendesk/adminhtml_zendesk/ticketsAll'),
+                'url'   => $this->getUrl('adminhtml/zendesk/ticketsAll'),
             );
             $label = $this->__("All tickets");
             
@@ -96,7 +96,7 @@ class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Grids extends Mage_Adminhtml_Blo
                     $this->addTab($viewId, array(
                         'label' => $label,
                         'class' => 'ajax',
-                        'url'   => $this->getUrl('zendesk/adminhtml_zendesk/ticketsView', array('viewid' => $viewId)),
+                        'url'   => $this->getUrl('adminhtml/zendesk/ticketsView', array('viewid' => $viewId)),
                     ));
                 } else {
                     Mage::unregister('zendesk_tickets_view');


### PR DESCRIPTION
The previous route used to generate the URL to display the tickets was not resolving properly on the new digital ocean server, which caused the tickets not to display. We updated it to get a proper URL which works for digital ocean and our local servers. 

/cc @miogalang @jwswj @mmolina @joh90 

**Before**
![404](https://cloud.githubusercontent.com/assets/1302819/7856862/effc000a-055e-11e5-94ee-13d9b5969517.png)

**After**
![working](https://cloud.githubusercontent.com/assets/1302819/7856909/2486d962-055f-11e5-9ba2-524702bc8aca.png)
### Risks
- Medium: The ticket view might not load correctly.
