### PR TITLE
[MI-98] Update routes for getUrl call on bulk actions

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Tab/Tickets/Grid/Abstract.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Tab/Tickets/Grid/Abstract.php
@@ -97,13 +97,13 @@ abstract class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Tab_Tickets_Grid_Abstra
         
         $this->getMassactionBlock()->addItem('delete', array(
             'label'         => Mage::helper('zendesk')->__('Delete'),
-            'url'           => $this->getUrl('*/adminhtml_zendesk/bulkDelete', array('form_key' => $formKey, '_current' => true)),
+            'url'           => $this->getUrl('adminhtml/zendesk/bulkDelete', array('form_key' => $formKey, '_current' => true)),
             'confirm'       => Mage::helper('zendesk')->__('Are you sure you want to delete selected tickets?')
         ));
        
         $this->getMassactionBlock()->addItem('change_status', array(
             'label'         => Mage::helper('zendesk')->__('Change Status'),
-            'url'           => $this->getUrl('*/adminhtml_zendesk/bulkChangeStatus', array('form_key' => $formKey, '_current' => true)),
+            'url'           => $this->getUrl('adminhtml/zendesk/bulkChangeStatus', array('form_key' => $formKey, '_current' => true)),
             'confirm'       => Mage::helper('zendesk')->__('Are you sure you want to change status of selected tickets?'),
             'additional'    => array(
                 'visibility'    => array(
@@ -118,7 +118,7 @@ abstract class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Tab_Tickets_Grid_Abstra
         
         $this->getMassactionBlock()->addItem('change_priority', array(
             'label'         => Mage::helper('zendesk')->__('Change Priority'),
-            'url'           => $this->getUrl('*/adminhtml_zendesk/bulkChangePriority', array('form_key' => $formKey, '_current' => true)),
+            'url'           => $this->getUrl('adminhtml/zendesk/bulkChangePriority', array('form_key' => $formKey, '_current' => true)),
             'confirm'       => Mage::helper('zendesk')->__('Are you sure you want to change priority of selected tickets?'),
             'additional'    => array(
                 'visibility'    => array(
@@ -133,7 +133,7 @@ abstract class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Tab_Tickets_Grid_Abstra
         
         $this->getMassactionBlock()->addItem('change_type', array(
             'label'         => Mage::helper('zendesk')->__('Change Type'),
-            'url'           => $this->getUrl('*/adminhtml_zendesk/bulkChangeType', array('form_key' => $formKey, '_current' => true)),
+            'url'           => $this->getUrl('adminhtml/zendesk/bulkChangeType', array('form_key' => $formKey, '_current' => true)),
             'confirm'       => Mage::helper('zendesk')->__('Are you sure you want to change type of selected tickets?'),
             'additional'    => array(
                 'visibility'    => array(
@@ -148,7 +148,7 @@ abstract class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Tab_Tickets_Grid_Abstra
         
         $this->getMassactionBlock()->addItem('mark_as_spam', array(
             'label'         => Mage::helper('zendesk')->__('Mark as Spam'),
-            'url'           => $this->getUrl('*/adminhtml_zendesk/bulkMarkSpam', array('form_key' => $formKey, '_current' => true)),
+            'url'           => $this->getUrl('adminhtml/zendesk/bulkMarkSpam', array('form_key' => $formKey, '_current' => true)),
             'confirm'       => Mage::helper('zendesk')->__('Are you sure you want to mark as spam selected tickets?'),
         ));
         

--- a/src/app/design/adminhtml/default/default/template/zendesk/customer/tickets.phtml
+++ b/src/app/design/adminhtml/default/default/template/zendesk/customer/tickets.phtml
@@ -61,7 +61,7 @@ if($customer = Mage::registry('current_customer')) {
                                 <td><?php echo Mage::helper('core')->formatDate($ticket['created_at'], Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true); ?></td>
                                 <td><?php echo Mage::helper('core')->formatDate($ticket['updated_at'], Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true); ?></td>
                                 <td><?php echo ucwords($ticket['status']); ?></td>
-                                <td><?php echo ($ticket['group_id']) ? $t['group']['name'] : ''; ?></td>
+                                <td><?php echo (isset($ticket['group_id'])) ? $t['group']['name'] : ''; ?></td>
                                 <td><?php echo ($ticket['assignee_id']) ? $t['assignee']['name'] : ''; ?></td>
                             </tr>
                         <?php endforeach; ?>


### PR DESCRIPTION
Fixes the bulk update issue originating from this ticket https://support.zendesk.com/agent/tickets/1126595 . This has been tested in Magento CE 1.9.1 and Magento CE 1.8.1 .

Fixed:
Performing a bulk update on the tickets grid will redirect to a 404 page.

/cc @miogalang @jwswj @mmolina
### References
- Jira link: https://zendesk.atlassian.net/browse/MI-98
### Risks
- Medium - Functionality may be broken when rendering the grid on other pages
