### PR TITLE
Admin SSO fix for Magento 1.9

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
@@ -224,4 +224,18 @@ EOJS;
         Mage::getModel('zendesk/api_users')->create($data);
     }
     
+    public function checkSsoRedirect($user)
+    {
+        if (
+            Mage::helper('zendesk')->isSSOAdminUsersEnabled() && 
+            Mage::app()->getRequest()->getControllerName() === 'zendesk' && 
+            Mage::app()->getRequest()->getActionName() === 'authenticate'
+        ) {
+            Mage::app()->getResponse()
+                ->setRedirect(Mage::helper('adminhtml')->getUrl('*/zendesk/authenticate'))
+                ->sendHeaders()
+                ->sendResponse();
+            exit();
+        }
+    }
 }

--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -19,7 +19,7 @@ require_once(Mage::getModuleDir('', 'Zendesk_Zendesk') . DS . 'Helper' . DS . 'J
 
 class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Controller_Action
 {
-    protected $_publicActions = array('redirect', 'authenticate');
+    protected $_publicActions = array('redirect', 'logout');
 
     public function indexAction()
     {
@@ -147,12 +147,13 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
     {
         // Admin sessions do not currently have an explicit "logout" method (unlike customer sessions) so do this
         // manually with the session object
+
         $adminSession = Mage::getSingleton('admin/session');
         $adminSession->unsetAll();
         $adminSession->getCookie()->delete($adminSession->getSessionName());
         $adminSession->addSuccess(Mage::helper('adminhtml')->__('You have logged out.'));
 
-        $this->_redirect('adminhtml/zendesk/*');
+        $this->_redirect('adminhtml/zendesk/authenticate');
     }
 
     public function createAction()

--- a/src/app/code/community/Zendesk/Zendesk/etc/config.xml
+++ b/src/app/code/community/Zendesk/Zendesk/etc/config.xml
@@ -61,6 +61,16 @@
                 </connection>
             </zendesk_read>
         </resources>
+        <events>
+            <admin_session_user_login_success>
+                <observers>
+                    <zendesk>
+                        <class>zendesk/observer</class>
+                        <method>checkSsoRedirect</method>
+                    </zendesk>
+                </observers>
+            </admin_session_user_login_success>
+        </events>
     </global>
     <frontend>
         <routers>
@@ -171,7 +181,6 @@
                     </zendesk>
                 </observers>
             </customer_save_commit_after>
-
         </events>
         <menu>
             <zendesk translate="title" module="zendesk">


### PR DESCRIPTION
Use an event observer to handle the redirect to the SSO authenticate action. 
The Magento version 1.9 update introduced a security feature that prevents redirects after admin logins if the URL has query parameters, that's why the previous implementation isn't compatible with Magento 1.9.

This patch was tested on Magento 1.9, http://dev1702.zendesk-store.com/ and http://dev1810.zendesk-store.com/ .

/cc @miogalang @jwswj @mmolina @atroche 
### References
- Jira link: https://zendesk.atlassian.net/browse/MI-97
### Risks
- Low - a redirect loop might occur
### Notes
- The admin SSO url (/admin/zendesk/authenticate) was removed from the README , probably to discourage it's use?
