### PR TITLE
send customers to Requests page in Zendesk when clicking subject link…

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
@@ -22,9 +22,10 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
     {
         $protocol = 'https://';
         $domain = Mage::getStoreConfig('zendesk/general/domain');
-        $root = ($format === 'old') ? '' : '/agent/#';
+        $root = ($format === 'old') ? '' : '/agent';
 
         $base = $protocol . $domain . $root;
+        $hc = $protocol . $domain . '/hc';
        
         switch($object) {
             case '':
@@ -41,6 +42,10 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
 
             case 'raw':
                 return $protocol . $domain . '/' . $id;
+                break;
+            
+            case 'request':
+                return $hc . '/requests/' . $id;
                 break;
         }
     }
@@ -283,6 +288,19 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
     {   
         $path = Mage::getSingleton('admin/session')->getUser() ? 'adminhtml/zendesk/login' : '*/sso/login';
         $url = Mage::helper('adminhtml')->getUrl($path, array("return_url" => Mage::helper('core')->urlEncode(Mage::helper('zendesk')->getUrl('ticket', $row['id']))));
+        
+        if ($link)
+            return $url;
+        
+        $subject = $row['subject'] ? $row['subject'] : $this->__('No Subject');
+
+        return '<a href="' . $url . '" target="_blank">' .  Mage::helper('core')->escapeHtml($subject) . '</a>';
+    }
+    
+    public function getRequestUrl($row, $link = false)
+    {   
+        $path = Mage::getSingleton('admin/session')->getUser() ? 'adminhtml/zendesk/login' : '*/sso/login';
+        $url = Mage::helper('adminhtml')->getUrl($path, array("return_url" => Mage::helper('core')->urlEncode(Mage::helper('zendesk')->getUrl('request', $row['id']))));
         
         if ($link)
             return $url;

--- a/src/app/design/frontend/base/default/template/zendesk/customer/tickets/list.phtml
+++ b/src/app/design/frontend/base/default/template/zendesk/customer/tickets/list.phtml
@@ -38,7 +38,7 @@
                     <?php foreach($tickets as $ticket): ?>
                         <?php $t = Mage::getModel('zendesk/api_tickets')->get($ticket['id'], true); ?>
                         <tr class="border">
-                            <td><?php echo Mage::helper('zendesk')->getTicketUrl($ticket); ?></td>
+                            <td><?php echo Mage::helper('zendesk')->getRequestUrl($ticket); ?></td>
                             <td><?php echo Mage::helper('core')->formatDate($ticket['created_at'], Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true); ?></td>
                             <td><?php echo Mage::helper('core')->formatDate($ticket['updated_at'], Mage_Core_Model_Locale::FORMAT_TYPE_MEDIUM, true); ?></td>
                             <td><?php echo ucwords($ticket['status']); ?></td>


### PR DESCRIPTION
send customers to Requests page in Zendesk when clicking subject link…

also removed /# from agent path as it is no longer used in Zendesk.

https://support.zendesk.com/agent/tickets/1171129
