### PR TITLE
[MI-277] Sideload users

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Tab/Tickets/Grid/Abstract.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Tab/Tickets/Grid/Abstract.php
@@ -171,10 +171,11 @@ abstract class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Tab_Tickets_Grid_Abstra
             'filter'    => $filter,
             'index'     => $index,
             'type'      => $this->getColumnType($index),
+            'users'     => $this->getCollection()->users,
         );
         
         $renderer = $this->getColumnRenderer($index);
-        
+
         if($renderer !== null) {
             $column['renderer'] = $renderer;
         }
@@ -241,5 +242,18 @@ abstract class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Tab_Tickets_Grid_Abstra
         
         return $js;
     }
-    
+
+    /**
+     * Override the parent method so that $this->_prepareCollection() is called first
+     *
+     * @return $this
+     */
+    protected function _prepareGrid()
+    {
+        $this->_prepareCollection();
+        $this->_prepareColumns();
+        $this->_prepareMassactionBlock();
+
+        return $this;
+    }
 }

--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Tab/Tickets/Grid/All.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Tab/Tickets/Grid/All.php
@@ -55,6 +55,7 @@ class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Tab_Tickets_Grid_All extends Zen
             'renderer'  => 'zendesk/adminhtml_dashboard_tab_tickets_grid_renderer_email',
             'index'     => 'requester_id',
             'sortable'  => false,
+            'users'     => $this->getCollection()->users,
         ));
 
         $this->addColumn('type', array(
@@ -73,15 +74,6 @@ class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Tab_Tickets_Grid_All extends Zen
             'index'     => 'status',
             'type'      => 'options',
             'options'   => Mage::helper('zendesk')->getStatusMap(),
-        ));
-
-        $this->addColumn('priority', array(
-            'header'    => Mage::helper('zendesk')->__('Priority'),
-            'sortable'  => true,
-            'width'     => '100px',
-            'index'     => 'priority',
-            'type'      => 'options',
-            'options'   => Mage::helper('zendesk')->getPriorityMap(),
         ));
 
         $this->addColumn('created_at', array(

--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Tab/Tickets/Grid/Renderer/Email.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Tab/Tickets/Grid/Renderer/Email.php
@@ -19,7 +19,7 @@
 class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Tab_Tickets_Grid_Renderer_Email extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract {
 
     public function render(Varien_Object $row) {
-        $users = Mage::registry('zendesk_users');
+        $users = $this->getColumn()->users;
         $value = (int) $row->getData($this->getColumn()->getIndex());
 
         if ($users) {

--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Tab/Tickets/Grid/Renderer/User.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Tab/Tickets/Grid/Renderer/User.php
@@ -19,19 +19,19 @@
 class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Tab_Tickets_Grid_Renderer_User extends Mage_Adminhtml_Block_Widget_Grid_Column_Renderer_Abstract {
 
     public function render(Varien_Object $row) {
-        $users = Mage::registry('zendesk_users') ? Mage::registry('zendesk_users') : array();
+        $users = $this->getColumn()->users;
         $value = (int) $row->getData($this->getColumn()->getIndex());
-        
+
         $found = array_filter($users, function($user) use($value) {
             return (int) $user['id'] === $value;
         });
-        
+
         if( count($found) ) {
             $user = array_shift($found);
-            
+
             return $user['name'];
         }
-        
+
         return '';
     }
 

--- a/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
@@ -395,16 +395,6 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
     public function storeDependenciesInCachedRegistry() {
         $cache = Mage::app()->getCache();
 
-        if (null == Mage::registry('zendesk_users')) {
-            if( $cache->load('zendesk_users') === false) {
-                $users = serialize( Mage::getModel('zendesk/api_users')->all() );
-                $cache->save($users, 'zendesk_users', array('zendesk', 'zendesk_users'), 300);
-            }
-
-            $users  = unserialize( $cache->load('zendesk_users') );
-            Mage::register('zendesk_users', $users);
-        }
-
         if (null == Mage::registry('zendesk_groups')) {
             if( $cache->load('zendesk_groups') === false) {
                 $groups = serialize( Mage::getModel('zendesk/api_groups')->all() );

--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/Tickets.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/Tickets.php
@@ -82,20 +82,21 @@ class Zendesk_Zendesk_Model_Api_Tickets extends Zendesk_Zendesk_Model_Api_Abstra
 
     public function recent()
     {
-        $response = $this->_call('tickets/recent.json');
+        $response = $this->_call('tickets/recent.json', array('include' => 'users,groups'));
 
         return $response['tickets'];
     }
 
     public function all()
     {
-        $response = $this->_call('tickets.json');
+        $response = $this->_call('tickets.json', array('include' => 'users,groups'));
         return $response['tickets'];
     }
     
     public function search($data)
     {
-        return $this->_call('search.json', $data);
+        $data['include'] = 'users,groups';
+        return $this->_call('search/incremental', $data);
     }
         
     public function forOrder($orderIncrementId)

--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/Views.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/Views.php
@@ -39,6 +39,7 @@ class Zendesk_Zendesk_Model_Api_Views extends Zendesk_Zendesk_Model_Api_Abstract
             throw new InvalidArgumentException('View ID not provided');
         }
 
+        $params['include'] = 'users,groups';
         $paramsString = count($params) ? '?' . http_build_query($params) : '';
 
         $response = $this->_call('views/' . $id . '/execute.json' . $paramsString);


### PR DESCRIPTION
Sideloads the users instead of caching all users on page load. 
### Note

This PR **removes** the `Priority` column from all grids. The reason for this is because to enable sideloading - we must use /search/incremental which does not return the `priority` field. 

/cc @miogalang @jwswj @mmolina @iandjx 
### References
- Jira link: https://zendesk.atlassian.net/browse/MI-277
### Risks
- Medium - Users may not be loaded or an unexpected response is returned by the `incremental` endpoint
