### PR TITLE
Allow syncing multiple times

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/Users.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/Users.php
@@ -59,7 +59,7 @@ class Zendesk_Zendesk_Model_Api_Users extends Zendesk_Zendesk_Model_Api_Abstract
         while($page && $response = $this->_call('users.json?page=' . $page)) {
             $users      = array_merge($users, $response['users']);
             $page       = is_null($response['next_page']) ? 0 : $page + 1;
-    }
+        }
     
         return $users;
     }
@@ -114,5 +114,22 @@ class Zendesk_Zendesk_Model_Api_Users extends Zendesk_Zendesk_Model_Api_Abstract
         }
  
         return $response['user_field'];
+    }
+
+    /**
+     * Fetch all user fields
+     * 
+     * @return array $userFields
+     */
+    public function getUserFields()
+    {
+        $page = 1;
+        $userFields = array();
+        while($page && $response = $this->_call('user_fields.json?page=' . $page)) {
+            $userFields = array_merge($userFields, $response['user_fields']);
+            $page       = is_null($response['next_page']) ? 0 : $page + 1;
+        }
+    
+        return $userFields;
     }
 }

--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -526,7 +526,9 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
         $this->getResponse()->clearHeaders()->setHeader('Content-type','application/json',true);
         Mage::log('Synchronization started', null, 'zendesk.log');
         try {
-            $user = Mage::getModel('zendesk/api_users')->all();
+            $userFieldKeys = array_column(Mage::getModel('zendesk/api_users')->getUserFields(), 'key');
+            $user = Mage::getModel('zendesk/api_users')->me();
+
             if (is_null($user))
                 throw new Exception("Connection Failed");
 
@@ -593,7 +595,11 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
             );
 
             foreach($data as $field) {
+                if (in_array($field['user_field']['key'], $userFieldKeys))
+                    continue;
+
                 $response = Mage::getModel('zendesk/api_users')->createUserField($field);
+
                 if (!isset($response['active']) || $response['active'] === false)
                     Mage::log('Unable to create User Field with key '.$field['user_field']['key'], null, 'zendesk.log');
             }

--- a/src/app/code/community/Zendesk/Zendesk/functions.php
+++ b/src/app/code/community/Zendesk/Zendesk/functions.php
@@ -1,0 +1,116 @@
+<?php
+
+if (!function_exists('array_column')) {
+	/**
+	 * This file is part of the array_column library
+	 *
+	 * For the full copyright and license information, please view the LICENSE
+	 * file that was distributed with this source code.
+	 *
+	 * @copyright Copyright (c) Ben Ramsey (http://benramsey.com)
+	 * @license http://opensource.org/licenses/MIT MIT
+	 */
+
+	/**
+	 * Returns the values from a single column of the input array, identified by
+	 * the $columnKey.
+	 *
+	 * Optionally, you may provide an $indexKey to index the values in the returned
+	 * array by the values from the $indexKey column in the input array.
+	 *
+	 * @param array $input A multi-dimensional array (record set) from which to pull
+	 *                     a column of values.
+	 * @param mixed $columnKey The column of values to return. This value may be the
+	 *                         integer key of the column you wish to retrieve, or it
+	 *                         may be the string key name for an associative array.
+	 * @param mixed $indexKey (Optional.) The column to use as the index/keys for
+	 *                        the returned array. This value may be the integer key
+	 *                        of the column, or it may be the string key name.
+	 * @return array
+	 */
+	function array_column($input = null, $columnKey = null, $indexKey = null)
+	{
+		// Using func_get_args() in order to check for proper number of
+		// parameters and trigger errors exactly as the built-in array_column()
+		// does in PHP 5.5.
+		$argc = func_num_args();
+		$params = func_get_args();
+
+		if ($argc < 2) {
+			trigger_error("array_column() expects at least 2 parameters, {$argc} given", E_USER_WARNING);
+			return null;
+		}
+
+		if (!is_array($params[0])) {
+			trigger_error(
+				'array_column() expects parameter 1 to be array, ' . gettype($params[0]) . ' given',
+				E_USER_WARNING
+			);
+			return null;
+		}
+
+		if (!is_int($params[1])
+			&& !is_float($params[1])
+			&& !is_string($params[1])
+			&& $params[1] !== null
+			&& !(is_object($params[1]) && method_exists($params[1], '__toString'))
+		) {
+			trigger_error('array_column(): The column key should be either a string or an integer', E_USER_WARNING);
+			return false;
+		}
+
+		if (isset($params[2])
+			&& !is_int($params[2])
+			&& !is_float($params[2])
+			&& !is_string($params[2])
+			&& !(is_object($params[2]) && method_exists($params[2], '__toString'))
+		) {
+			trigger_error('array_column(): The index key should be either a string or an integer', E_USER_WARNING);
+			return false;
+		}
+
+		$paramsInput = $params[0];
+		$paramsColumnKey = ($params[1] !== null) ? (string) $params[1] : null;
+
+		$paramsIndexKey = null;
+		if (isset($params[2])) {
+			if (is_float($params[2]) || is_int($params[2])) {
+				$paramsIndexKey = (int) $params[2];
+			} else {
+				$paramsIndexKey = (string) $params[2];
+			}
+		}
+
+		$resultArray = array();
+
+		foreach ($paramsInput as $row) {
+			$key = $value = null;
+			$keySet = $valueSet = false;
+
+			if ($paramsIndexKey !== null && array_key_exists($paramsIndexKey, $row)) {
+				$keySet = true;
+				$key = (string) $row[$paramsIndexKey];
+			}
+
+			if ($paramsColumnKey === null) {
+				$valueSet = true;
+				$value = $row;
+			} elseif (is_array($row) && array_key_exists($paramsColumnKey, $row)) {
+				$valueSet = true;
+				$value = $row[$paramsColumnKey];
+			}
+
+			if ($valueSet) {
+				if ($keySet) {
+					$resultArray[$key] = $value;
+				} else {
+					$resultArray[] = $value;
+				}
+			}
+
+		}
+
+		return $resultArray;
+	}
+
+}


### PR DESCRIPTION
Under Zendesk > Configuration, the "Sync All Customers And Create User Fields" button is usually only clicked once to create the user fields on Zendesk. In the case where this button is pressed more than once, an error will be displayed, which may cause confusion for some users.

![screen shot 2015-09-15 at 2 07 10 pm](https://cloud.githubusercontent.com/assets/1302819/9869130/17605808-5bb3-11e5-9c50-4400480aa63d.png)

This PR resolves this by comparing existing user fields to the one's created by this function.

/cc @miogalang @jwswj @mmolina @iandjx 
### References
- Jira link: 
### Risks
- Medium: user fields added by other applications may have their values overwritten
