### PR TITLE
[MI-265] Set current user as submitter

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -340,11 +340,18 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
             }
 
             try {
-                $admin = Mage::getModel('zendesk/api_users')->me();
+                $admin = Mage::getSingleton('admin/session')->getUser();
+                $submitter = Mage::getModel('zendesk/api_users')->find($admin->getEmail());
+
+                if (!$submitter) {
+                    // Default to the user set in the agent email field under Configuration
+                    $submitter = Mage::getModel('zendesk/api_users')->me();
+                }
+
                 $ticket = array(
                     'ticket' => array(
                         'requester_id' => $requesterId,
-                        'submitter_id' => $admin['id'],
+                        'submitter_id' => $submitter['id'],
                         'subject' => $data['subject'],
                         'status' => $data['status'],
                         'priority' => $data['priority'],


### PR DESCRIPTION
Sets the currently logged in Magento user as the submitter, IF that user is a verified Zendesk agent/admin. The issue was raised in the support ticket below.

/cc @miogalang @jwswj @mmolina @iandjx 
### References
- Jira Link: https://zendesk.atlassian.net/browse/MI-265 (different description)
- Support Ticket: https://support.zendesk.com/agent/tickets/1189070
### Risks
- Medium: a submitter may not be specified, leaving the "via" field blank in the ticket
