### PR TITLE
[MI-100] Check connection status before loading the grid

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard.php
@@ -31,11 +31,6 @@ class Zendesk_Zendesk_Block_Adminhtml_Dashboard extends Mage_Adminhtml_Block_Tem
         return 'Token token="' . Mage::helper('zendesk')->getApiToken(false) . '"';
     }
 
-    public function isConnected() {
-        $connection = Mage::helper('zendesk')->getConnectionStatus();
-        return $connection['success'];
-    }
-
     public function getTotals() {
         return Mage::helper("zendesk")->getTicketTotals();
     }

--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Grids.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Grids.php
@@ -29,7 +29,7 @@ class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Grids extends Mage_Adminhtml_Blo
     protected function _prepareLayout() {
         // Check if we are on the main admin dashboard and, if so, whether we should be showing the grid
         // Note: an additional check in the template is needed, but this will prevent unnecessary API calls to Zendesk
-        if ( !$this->getIsZendeskDashboard() && !Mage::getStoreConfig('zendesk/backend_features/show_on_dashboard') )
+        if ( !Mage::helper('zendesk')->isConnected() || (!$this->getIsZendeskDashboard() && !Mage::getStoreConfig('zendesk/backend_features/show_on_dashboard')) )
         {
             return parent::_prepareLayout();
         }

--- a/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
@@ -391,7 +391,17 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
             );
         }
     }
-    
+
+    /**
+     * Checks if the current connection details are valid.
+     *
+     * @return boolean
+     */
+    public function isConnected() {
+        $connection = $this->getConnectionStatus();
+        return $connection['success'];
+    }
+
     public function storeDependenciesInCachedRegistry() {
         $cache = Mage::app()->getCache();
 

--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -252,10 +252,11 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
 
     public function launchAction()
     {
-        $domain = $this->_domainConfigured();
-        if (!$domain) {
+        if (!$this->_domainConfigured()) {
             return;
         }
+
+        $domain = Mage::getStoreConfig('zendesk/general/domain');
 
         $sso = Mage::getStoreConfig('zendesk/sso/enabled');
 
@@ -749,13 +750,12 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
 
     private function _domainConfigured()
     {
-        $domain = Mage::getStoreConfig('zendesk/general/domain');
-        if(!$domain) {
-            Mage::getSingleton('adminhtml/session')->addError(Mage::helper('zendesk')->__('Please set up Zendesk connection.'));
+        if (!Mage::helper('zendesk')->isConnected()) {
+            Mage::getSingleton('adminhtml/session')->addError(Mage::helper('zendesk')->__('Please set up a Zendesk connection.'));
             $this->_redirect('adminhtml/dashboard');
             return false;
         } else {
-            return $domain;
+            return true;
         }
     }
 

--- a/src/app/design/adminhtml/default/default/template/zendesk/dashboard/index.phtml
+++ b/src/app/design/adminhtml/default/default/template/zendesk/dashboard/index.phtml
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 ?>
-<?php if( $this->isConnected() ): ?>
+<?php if( Mage::helper('zendesk')->isConnected() ): ?>
     <?php if ($this->getIsZendeskDashboard() || Mage::getStoreConfig('zendesk/backend_features/show_on_dashboard')): ?>
         <?php if ($this->getIsZendeskDashboard()): ?>
             <div class="content-header">


### PR DESCRIPTION
Do not display Create Ticket and Dashboard/Grid if the extension is not setup properly.

related PR: #77 

Steps to reproduce:
1. Login to the magento backend.
2. Go to Zendesk > Configuration.
3. In the General tab, make all fields empty except for Zendesk Domain.
    In the Admin Backend tab, set "Show support tickets on admin dashboard" to "Yes".
4. Click Save.
1. Go to Zendesk > Dashboard

Expected Result:
1. "Couldn't authenticate you" should appear as an error message.
2. On step #5 - the configuration notice should be displayed

Actual Result:
1. A php warning (attached) appears, along with the standard error message.

![screen shot 2015-06-22 at 3 48 57 pm](https://cloud.githubusercontent.com/assets/1302819/8298639/c5ac70fc-199d-11e5-9294-0e856f1bf3ad.png)
1. On step #5 - a fatal error is thrown and halts the process (attached)

![screen shot 2015-06-22 at 4 00 41 pm](https://cloud.githubusercontent.com/assets/1302819/8298640/ca5414de-199d-11e5-85ac-bd6f632c21be.png)

/cc @miogalang @jwswj @mmolina @iandjx 
### References
- Jira link: https://zendesk.atlassian.net/browse/MI-100
## QA notes
- Developer mode must be enabled
### Risks
- Medium - Extension functionality may be affected.
