### PR TITLE
"Test Connection" button improvement

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
@@ -360,10 +360,24 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
     public function getFormatedDateTime($dateToFormat) {
         return Mage::helper('core')->formatDate($dateToFormat, 'medium', true);
     }
-    
-    public function getConnectionStatus() {
+
+    /**
+     * Tests if the provided username and password is correct. If either is empty the database values will be used.
+     *
+     * @param  string $domain
+     * @param  string $username
+     * @param  string $password
+     * @return array
+     */
+    public function getConnectionStatus($domain = null, $username = null, $password = null) {
         try {
-            $user = Mage::getModel('zendesk/api_users')->me();
+            $usersApi = Mage::getModel('zendesk/api_users');
+
+            $usersApi->setUsername($username);
+            $usersApi->setPassword($password);
+            $usersApi->setDomain($domain);
+
+            $user = $usersApi->me();
 
             if(isset($user['id'])) {
                 return array(

--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/Abstract.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/Abstract.php
@@ -17,9 +17,70 @@
 
 class Zendesk_Zendesk_Model_Api_Abstract extends Mage_Core_Model_Abstract
 {
+    protected $username = null;
+    protected $password = null;
+    protected $domain = null;
+
+    /**
+     * Sets the domain to be used for this instance
+     * 
+     * @param string $username The user domain
+     */
+    public function setDomain($domain)
+    {
+        $this->domain = $domain;
+    }
+
+    /**
+     * Sets the email to be used for this instance
+     * 
+     * @param string $username The user email
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * Sets the API token for this instance
+     * 
+     * @param string $password The API token
+     */
+    public function setPassword($password)
+    {
+        $this->password = $password;
+    }
+
+    public function getUsername()
+    {
+        if ($this->username === null) {
+            $this->username = Mage::getStoreConfig('zendesk/general/email');
+        }
+
+        return $this->username . '/token';
+    }
+
+    public function getPassword()
+    {
+        if ($this->password === null) {
+            $this->password = Mage::getStoreConfig('zendesk/general/password');
+        }
+
+        return $this->password; 
+    }
+
+    public function getDomain()
+    {
+        if ($this->domain === null) {
+            $this->domain = Mage::getStoreConfig('zendesk/general/domain');
+        }
+
+        return $this->domain; 
+    }
+
     protected function _getUrl($path)
     {
-        $base_url = 'https://' . Mage::getStoreConfig('zendesk/general/domain') . '/api/v2';
+        $base_url = 'https://' . $this->getDomain() . '/api/v2';
         $path = trim($path, '/');
         return $base_url . '/' . $path;
     }
@@ -48,8 +109,8 @@ class Zendesk_Zendesk_Model_Api_Abstract extends Mage_Core_Model_Abstract
         );
 
         $client->setAuth(
-            Mage::getStoreConfig('zendesk/general/email'). '/token',
-            Mage::getStoreConfig('zendesk/general/password')
+            $this->getUsername(),
+            $this->getPassword()
         );
 
         if($method == 'POST' || $method == "PUT") {

--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -463,7 +463,13 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
 
     public function checkOutboundAction()
     {
-        $connection = Mage::helper('zendesk')->getConnectionStatus();
+        $request = Mage::app()->getRequest();
+
+        $connection = Mage::helper('zendesk')->getConnectionStatus(
+            $request->getParam('domain'),
+            $request->getParam('username'),
+            $request->getParam('password')
+        );
 
         $this->getResponse()->clearHeaders()->setHeader('Content-type','application/json', true);
         $this->getResponse()->setBody(json_encode($connection));

--- a/src/app/design/adminhtml/default/default/template/zendesk/config/button-test-zendesk.phtml
+++ b/src/app/design/adminhtml/default/default/template/zendesk/config/button-test-zendesk.phtml
@@ -22,6 +22,11 @@
     function checkZendApiConnection() {
         var request = new Ajax.Request('<?php echo $this->getUrl('adminhtml/zendesk/checkOutbound'); ?>', {
             method: 'get',
+            parameters: {
+                domain: document.getElementById('zendesk_general_domain').value,
+                username: document.getElementById('zendesk_general_email').value,
+                password: document.getElementById('zendesk_general_password').value
+            },
             onCreate: function() {
                 document.getElementById('zendesk-api-connection-results').innerHTML = '';
             },


### PR DESCRIPTION
Currently the "Test Connection" button in Zendesk > Configuration > General requires users to click "Save Config" so that the values entered may be tested. This PR uses the current input field values to test the connection.

Planning to release this with #100 .

/cc @miogalang @jwswj @iandjx 
### References
- Jira link: 
### Risks
- Medium: Connection details may not be retrieved or incorrect values may be passed unexpectedly.
