### PR TITLE
7ochem/prevent php notice undefined index

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/Requesters.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/Requesters.php
@@ -36,6 +36,6 @@ class Zendesk_Zendesk_Model_Api_Requesters extends Zendesk_Zendesk_Model_Api_Use
         );
         $response = $this->_call('users.json', null, 'POST', $data);
 
-        return $response['user'];
+        return (isset($response['user']) ? $response['user'] : null);
     }
 }

--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/Tickets.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/Tickets.php
@@ -84,13 +84,13 @@ class Zendesk_Zendesk_Model_Api_Tickets extends Zendesk_Zendesk_Model_Api_Abstra
     {
         $response = $this->_call('tickets/recent.json', array('include' => 'users,groups'));
 
-        return $response['tickets'];
+        return (isset($response['tickets']) ? $response['tickets'] : null);
     }
 
     public function all()
     {
         $response = $this->_call('tickets.json', array('include' => 'users,groups'));
-        return $response['tickets'];
+        return (isset($response['tickets']) ? $response['tickets'] : null);
     }
     
     public function search($data)
@@ -189,7 +189,7 @@ class Zendesk_Zendesk_Model_Api_Tickets extends Zendesk_Zendesk_Model_Api_Abstra
     {
         $response = $this->_call('tickets.json', null, 'POST', $data);
         
-        return $response['ticket'];
+        return (isset($response['ticket']) ? $response['ticket'] : null);
     }
 
 }

--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/Users.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/Users.php
@@ -37,7 +37,7 @@ class Zendesk_Zendesk_Model_Api_Users extends Zendesk_Zendesk_Model_Api_Abstract
     {
         $response = $this->_call('users/me.json');
 
-        return $response['user'];
+        return (isset($response['user']) ? $response['user'] : null);
     }
 
     public function get($id)
@@ -48,7 +48,7 @@ class Zendesk_Zendesk_Model_Api_Users extends Zendesk_Zendesk_Model_Api_Abstract
 
         $response = $this->_call('users/' . $id . '.json');
 
-        return $response['user'];
+        return (isset($response['user']) ? $response['user'] : null);
     }
 
     public function all()
@@ -72,37 +72,37 @@ class Zendesk_Zendesk_Model_Api_Users extends Zendesk_Zendesk_Model_Api_Abstract
         
         $response = $this->_call('end_users/'. $id .'.json');
         
-        return $response['user'];
+        return (isset($response['user']) ? $response['user'] : null);
     }
     
     public function getIdentities($id)
     {
         $response = $this->_call('users/' . $id . '/identities.json');
-        return $response['identities'];
+        return (isset($response['identities']) ? $response['identities'] : null);
     }
     
     public function setPrimaryIdentity($user_id, $identity_id)
     {
         $response = $this->_call('users/' . $user_id . '/identities/'.$identity_id.'/make_primary.json', null, 'PUT', null, true);
-        return $response['identities'];
+        return (isset($response['identities']) ? $response['identities'] : null);
     }
     
     public function addIdentity($user_id, $data)
     {
         $response = $this->_call('users/' . $user_id . '/identities.json', null, 'POST', $data, true);
-        return $response['identity'];
+        return (isset($response['identity']) ? $response['identity'] : null);
     }
     
     public function update($user_id, $user)
     {
         $response = $this->_call('users/' . $user_id . '.json', null, 'PUT', $user, true);
-        return $response['user'];
+        return (isset($response['user']) ? $response['user'] : null);
     }
     
     public function create($user)
     {
         $response = $this->_call('users.json', null, 'POST', $user, true);
-        return $response['user'];
+        return (isset($response['user']) ? $response['user'] : null);
     }
     
     public function createUserField($field)

--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/Views.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/Views.php
@@ -20,7 +20,7 @@ class Zendesk_Zendesk_Model_Api_Views extends Zendesk_Zendesk_Model_Api_Abstract
     public function active()
     {
         $response = $this->_call('views/active.json');
-        return $response['views'];
+        return (isset($response['views']) ? $response['views'] : null);
     }
 
     public function get($id)
@@ -30,7 +30,7 @@ class Zendesk_Zendesk_Model_Api_Views extends Zendesk_Zendesk_Model_Api_Abstract
         }
 
         $response = $this->_call('views/' . $id . '.json');
-        return $response['view'];
+        return (isset($response['view']) ? $response['view'] : null);
     }
 
     public function execute($id, array $params = array())


### PR DESCRIPTION
Check if the response has 'users' set. In case of an error returned by the API, `$response['users']` is not set and a notice like "ERR (3): Notice: Undefined index: user in src/app/code/community/Zendesk/Zendesk/Model/Api/Users.php" will appear in the logs
