### PR TITLE
[MI-462] Add the API url to be sent to provisioning

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Config/Buttons/Signup.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Config/Buttons/Signup.php
@@ -51,6 +51,8 @@ class Zendesk_Zendesk_Block_Adminhtml_Config_Buttons_Signup extends Mage_Adminht
 
     public function getPostInfo()
     {
+        $stores = Mage::app()->getWebsites();
+
         $info = array(
             'magento_domain' => Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB),
             'magento_current_user_id' => Mage::getSingleton('admin/session')->getUser()->getUserId(),
@@ -59,6 +61,7 @@ class Zendesk_Zendesk_Block_Adminhtml_Config_Buttons_Signup extends Mage_Adminht
             'magento_callback' => Mage::helper('adminhtml')->getUrl('adminhtml/zendesk/redirect', array('type' => 'settings', 'id' => 'zendesk')),
             'magento_locale' => Mage::getStoreConfig('general/locale/code'),
             'magento_timezone' => Mage::getStoreConfig('general/locale/timezone'),
+            'magento_api_url' => Mage::getUrl('zendesk/api', array('_store' => $stores[1]->getDefaultStore()->getCode()))
         );
 
         $storeName = Mage::getStoreConfig('general/store_information/name');


### PR DESCRIPTION
Adds `magento_api_url` to provisioning for install purposes. 

When Magento is configured to add store code to URLs (admin > configuration > general > web > Add Store Code to URLs) , the frontend API URL would resolve to a 404. The solution to this is to add the store code before the URL.

**Notes**
This is a two-part solution where `magento_api_url` should be used in zendesk_provisioning to accommodate the change.

/cc @zendesk/mintegrations @mmolina @miketineo @liulikun 
### References
- Zendesk Ticket: https://support.zendesk.com/agent/tickets/1322614
- Jira link: https://zendesk.atlassian.net/browse/MI-462
### Risks
- Low: Provisioning could fail on existing installations because the $stores array could return empty. 
