### PR TITLE
Proposed fix for https://github.com/zendesk/magento_extension/issues/85

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard.php
@@ -24,7 +24,8 @@ class Zendesk_Zendesk_Block_Adminhtml_Dashboard extends Mage_Adminhtml_Block_Tem
     }
 
     public function getIsZendeskDashboard() {
-        return Mage::app()->getFrontController()->getRequest()->getControllerName() === 'zendesk';
+        $request = Mage::app()->getFrontController()->getRequest();
+        return $request && $request->getControllerName() === 'zendesk';
     }
 
     public function getAuthHeader() {

--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Grids.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Dashboard/Grids.php
@@ -120,6 +120,7 @@ class Zendesk_Zendesk_Block_Adminhtml_Dashboard_Grids extends Mage_Adminhtml_Blo
     }
     
     public function getIsZendeskDashboard() {
-        return Mage::app()->getFrontController()->getRequest()->getControllerName() === 'zendesk';
+        $request = Mage::app()->getFrontController()->getRequest();
+        return $request && $request->getControllerName() === 'zendesk';
     }
 }

--- a/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
@@ -18,38 +18,6 @@
 
 class Zendesk_Zendesk_Model_Observer
 {
-    public function setHook(Varien_Event_Observer $observer)
-    {
-        if (Mage::app()->getFrontController()->getAction()->getFullActionName() === 'adminhtml_dashboard_index')
-        {
-            $block = $observer->getBlock();
-            if ($block->getNameInLayout() === 'dashboard')
-            {
-                $block->getChild('totals')->setUseAsDashboardHook(true);
-            }
-        }
-    }
-
-    public function insertBlock(Varien_Event_Observer $observer)
-    {
-        if (Mage::app()->getFrontController()->getAction()->getFullActionName() === 'adminhtml_dashboard_index')
-        {
-            if ($observer->getBlock()->getUseAsDashboardHook())
-            {
-                $html = $observer->getTransport()->getHtml();
-                $zendeskDash = $observer->getBlock()->getLayout()
-                    ->createBlock('zendesk/adminhtml_dashboard')
-                    ->setName('zendesk_dashboard');
-                $zendeskGrid = $zendeskDash->getLayout()
-                    ->createBlock('zendesk/adminhtml_dashboard_grids')
-                    ->setName('zendesk_dashboard_grids');
-                $zendeskDash->setChild('zendesk_dashboard_grids', $zendeskGrid);
-                $html .= $zendeskDash->toHtml();
-                $observer->getTransport()->setHtml($html);
-            }
-        }
-    }
-
     public function saveConfig(Varien_Event_Observer $observer)
     {
         // Defaults for "global" scope

--- a/src/app/code/community/Zendesk/Zendesk/etc/config.xml
+++ b/src/app/code/community/Zendesk/Zendesk/etc/config.xml
@@ -149,22 +149,6 @@
                     </zendesk>
                 </observers>
             </core_block_abstract_prepare_layout_before>
-            <core_block_abstract_prepare_layout_after>
-                <observers>
-                    <zendesk>
-                        <class>zendesk/observer</class>
-                        <method>setHook</method>
-                    </zendesk>
-                </observers>
-            </core_block_abstract_prepare_layout_after>
-            <core_block_abstract_to_html_after>
-                <observers>
-                    <zendesk>
-                        <class>zendesk/observer</class>
-                        <method>insertBlock</method>
-                    </zendesk>
-                </observers>
-            </core_block_abstract_to_html_after>
             <admin_system_config_changed_section_zendesk>
                 <observers>
                     <zendesk>

--- a/src/app/design/adminhtml/default/default/layout/zendesk.xml
+++ b/src/app/design/adminhtml/default/default/layout/zendesk.xml
@@ -17,6 +17,14 @@
 */
 -->
 <layout>
+    <adminhtml_dashboard_index>
+        <reference name="content">
+            <block type="zendesk/adminhtml_dashboard" name="zendesk_dashboard">
+                <block type="zendesk/adminhtml_dashboard_grids" name="zendesk_dashboard_grids" />
+            </block>
+        </reference>
+    </adminhtml_dashboard_index>
+    
     <adminhtml_system_config_edit>
         <reference name="head">
             <action method="addCss">

--- a/src/app/design/adminhtml/default/default/template/zendesk/dashboard/index.phtml
+++ b/src/app/design/adminhtml/default/default/template/zendesk/dashboard/index.phtml
@@ -25,8 +25,16 @@
                     </tr>
                 </table>
             </div>
+        <?php else: ?>
+            <script>
+                document.observe('dom:loaded', function(){
+                    if($('dashboard_diagram_totals')) {
+                        $('dashboard_diagram_totals').insert({ after:$('zendesk_dashboard_container') });
+                    }
+                });
+            </script>
         <?php endif; ?>
-        <div class="zendesk_dashboard_container">
+        <div class="zendesk_dashboard_container" id="zendesk_dashboard_container">
             <?php echo $this->getChildHtml('zendesk_dashboard_grids') ?>
             <div id="tickets_grid_tab_content"></div>
             <?php if (!$this->getIsZendeskDashboard()): ?>


### PR DESCRIPTION
Fix for #85, which addresses the assumption `Mage::app()->getFrontController()` is always set.  It's best to see the comments in the ticket.

The short of it is that it removes `Mage::app()->getFrontController()` from the observer model since observers are not always called from a controller (eg, API, cron, command line, etc).
