### PR TITLE
Wrong scope for store

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
@@ -66,7 +66,7 @@ class Zendesk_Zendesk_Model_Observer
         }
 
         if($storeCode) {
-            $scope = 'store';
+            $scope = 'stores';
             $store = Mage::getModel('core/store')->load($storeCode);
             $scopeId = $store->getId();
         }


### PR DESCRIPTION
The scope for a store is not 'store' but 'stores'.  If you're going to use the contact form for ticket creation, you won't receive any tickets, because 'contacts/email/recipient_email' and 'zendesk/hidden/contact_email_old' are created with scope 'store' instead of 'stores'.

Edit: This bug will just occur when you save in store view mode. 
