### PR TITLE
removed unused $orderId parameter

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
@@ -102,7 +102,7 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
         return true;
     }
 
-    public function ordersAction($orderId)
+    public function ordersAction()
     {
         if(!$this->_authorise()) {
             return $this;


### PR DESCRIPTION
gets rid of PHP warning: "Warning: Missing argument 1 for Zendesk_Zendesk_ApiController::ordersAction()"
