### PR TITLE
[MI-1705 Fix an incorrect assumption that a core_store_group with ID 1 always exists.

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Config/Buttons/Signup.php
+++ b/src/app/code/community/Zendesk/Zendesk/Block/Adminhtml/Config/Buttons/Signup.php
@@ -51,7 +51,21 @@ class Zendesk_Zendesk_Block_Adminhtml_Config_Buttons_Signup extends Mage_Adminht
 
     public function getPostInfo()
     {
-        $stores = Mage::app()->getWebsites();
+        $websiteCode = Mage::app()->getRequest()->getParam('website');
+        if ($websiteCode) {
+            $website = Mage::getModel('core/website')->load($websiteCode);
+        } else {
+            $website = Mage::getModel('core/website')->getCollection()
+                     ->addFieldToFilter('is_default', 1)
+                     ->getFirstItem();
+        }
+
+        $storeCode = Mage::app()->getRequest()->getParam('store');
+        if ($storeCode) {
+            $store = Mage::getModel('core/store')->load($storeCode);
+        } else {
+            $store = $website->getDefaultStore();
+        }
 
         $info = array(
             'magento_domain' => Mage::getBaseUrl(Mage_Core_Model_Store::URL_TYPE_WEB),
@@ -61,22 +75,9 @@ class Zendesk_Zendesk_Block_Adminhtml_Config_Buttons_Signup extends Mage_Adminht
             'magento_callback' => Mage::helper('adminhtml')->getUrl('adminhtml/zendesk/redirect', array('type' => 'settings', 'id' => 'zendesk')),
             'magento_locale' => Mage::getStoreConfig('general/locale/code'),
             'magento_timezone' => Mage::getStoreConfig('general/locale/timezone'),
-            'magento_api_url' => Mage::getUrl('zendesk/api', array('_store' => $stores[1]->getDefaultStore()->getCode()))
+            'magento_api_url' => Mage::getUrl('zendesk/api', array('_store' => $store->getCode())),
+            'magento_store_name' => $website->getName(),
         );
-
-        $storeName = Mage::getStoreConfig('general/store_information/name');
-
-        if(!$storeName) {
-            $websites = Mage::getModel('core/website')->getCollection();
-            foreach($websites as $website) {
-                // Skip admin website
-                if($website->getName() == 'Admin' || $website->getName() == 'Main Website') continue;
-
-                $storeName = $website->getName();
-            }
-        }
-
-        $info['magento_store_name'] = (string)$storeName;
 
         return $info;
     }


### PR DESCRIPTION
/cc @zendesk/mintegrations 

### Description

* Fix an incorrect assumption that a core_store_group with ID 1 always exists.
* Fetch store and website from current configuration scope rather than making assumptions based on ordering

<img width="771" alt="screen shot 2017-06-21 at 1 25 21 am" src="https://user-images.githubusercontent.com/8102514/27346734-a932002e-5620-11e7-97c2-aaf65d6e50a8.png">

Steps to reproduce bug:

* Access the mysql database then execute the following query against the magento database:

``` 
UPDATE core_store_group SET group_id = 99 WHERE group_id = 1
```

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1705

### Risks
* [low] Passed name to zendesk_provisioning may still not be the name of the currently being configured scope
* [medium]  Could generate zendesk/api link for the incorrect store 