### PR TITLE
Bump to 2.1.10

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/etc/config.xml
+++ b/src/app/code/community/Zendesk/Zendesk/etc/config.xml
@@ -19,7 +19,7 @@
 <config>
     <modules>
         <Zendesk_Zendesk>
-            <version>2.1.9</version>
+            <version>2.1.10</version>
         </Zendesk_Zendesk>
     </modules>
     <zendesk>


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Patch bump to 2.1.10.

Releasing [PR](https://github.com/zendesk/magento_extension/pull/116) to remove an unnecessary argument in `ApiController::ordersAction`. Removes useless warnings from PHP.

### References
* PR: https://github.com/zendesk/magento_extension/pull/116

### Risks
* [low] could be incorrect SEMVER bump
