### PR TITLE
[MI-1583] Initialise config set when saving the configuration

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/ConfigSets.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/ConfigSets.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Copyright 2012 Zendesk.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class Zendesk_Zendesk_Model_Api_ConfigSets extends Zendesk_Zendesk_Model_Api_Abstract
+{
+    CONST DEFAULT_WIDGET_COLOR = '#78a300';
+
+    CONST DEFAULT_WIDGET_POSITION = 'right';
+
+    /**
+     * Finds the embeddable config sets in the account
+     *
+     * @return array
+     */
+    public function find()
+    {
+        $response = $this->_call('embeddable/config');
+
+        return $response ? $response['embeds'] : [];
+    }
+
+    /**
+     * Initializes Zendesk's WebWidget
+     *
+     * @param array $config
+     */
+    public function initialize($config = [])
+    {
+        $config = array_merge([], $this->_getDefaultWidgetConfig());
+
+        return $this->_call('embeddable/api/config_sets.json', null, 'POST', [
+            'config_set' => $config,
+        ]);
+    }
+
+    /**
+     * Override the _getUrl method to prevent appending the api/v2 base path
+     *
+     * @param string $path
+     * @return string
+     */
+    protected function _getUrl($path)
+    {
+        return 'https://' . $this->getDomain() . '/' . trim($path, '/');
+    }
+
+    /**
+     * Returns the default widget config
+     *
+     * @return array
+     */
+    private function _getDefaultWidgetConfig()
+    {
+        return [
+            'color' => self::DEFAULT_WIDGET_COLOR,
+            'position' => self::DEFAULT_WIDGET_POSITION,
+        ];
+    }
+}

--- a/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
@@ -101,17 +101,26 @@ class Zendesk_Zendesk_Model_Observer
         // If the zendesk domain is not found in the web widget snippet (wrapped with quotes), generate it again
         $zDomain = Mage::getStoreConfig('zendesk/general/domain', $storeCode);
         $widgetSnippet = Mage::getStoreConfig('zendesk/frontend_features/web_widget_code_snippet', $storeCode);
-        // Case insensitive search with single and double quotes, still better performance than 1 regexp search
-        if($zDomain && stripos($widgetSnippet, "'{$zDomain}'") === false && stripos($widgetSnippet, '"'.$zDomain.'"') === false) {
-            $webWidgetSnippet=<<<EOJS
+
+        if (! empty($zDomain)) {
+            if ((bool) Mage::getStoreConfig('zendesk/frontend_features/web_widget_code_active')) {
+                $embeds = Mage::getModel('zendesk/api_configsets')->find();
+                if (! isset($embeds['launcher'])) {
+                    Mage::getModel('zendesk/api_configsets')->initialize();
+                }
+            }
+
+            // Case insensitive search with single and double quotes, still better performance than 1 regexp search
+            $hasUnatchedSnippet = stripos($widgetSnippet, "'{$zDomain}'") === false && stripos($widgetSnippet, '"'.$zDomain.'"') === false;
+            if (! $hasUnmatchedSnippet) {
+                $webWidgetSnippet=<<<EOJS
 <!-- Start of Zendesk Widget script -->
 <script>/*<![CDATA[*/window.zEmbed||function(e,t){var n,o,d,i,s,a=[],r=document.createElement("iframe");window.zEmbed=function(){a.push(arguments)},window.zE=window.zE||window.zEmbed,r.src="javascript:false",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="display: none",d=document.getElementsByTagName("script"),d=d[d.length-1],d.parentNode.insertBefore(r,d),i=r.contentWindow,s=i.document;try{o=s}catch(c){n=document.domain,r.src='javascript:var d=document.open();d.domain="'+n+'";void(0);',o=s}o.open()._l=function(){var o=this.createElement("script");n&&(this.domain=n),o.id="js-iframe-async",o.src=e,this.t=+new Date,this.zendeskHost=t,this.zEQueue=a,this.body.appendChild(o)},o.write('<body onload="document._l();">'),o.close()}("https://assets.zendesk.com/embeddable_framework/main.js","{$zDomain}");/*]]>*/</script>
 <!-- End of Zendesk Widget script -->
 EOJS;
-
-            Mage::getModel('core/config')->saveConfig('zendesk/frontend_features/web_widget_code_active', 1);
-            Mage::getModel('core/config')->saveConfig('zendesk/frontend_features/web_widget_code_snippet', $webWidgetSnippet);
-        } elseif (empty($zDomain)) {
+                Mage::getModel('core/config')->saveConfig('zendesk/frontend_features/web_widget_code_snippet', $webWidgetSnippet);
+            }
+        } else {
             Mage::getModel('core/config')->saveConfig('zendesk/frontend_features/web_widget_code_snippet', '');
         }
     }


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

When the web widget is active, this change checks if the config set has already been set and sets it if it isn't.

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1583

### Risks
* [low] Adds at the most two API calls when saving the config, will add to the total time to save the config.
