### PR TITLE
disabled domain validation to allow mail addresses from new TLDs

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/Requesters.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/Requesters.php
@@ -19,7 +19,7 @@ class Zendesk_Zendesk_Model_Api_Requesters extends Zendesk_Zendesk_Model_Api_Use
 {
     public function create($email, $name = null)
     {
-        if(!Zend_Validate::is($email, 'EmailAddress')) {
+        if(!Zend_Validate::is($email, 'EmailAddress', array('domain' => false))) {
             throw new InvalidArgumentException('Invalid email address provided');
         }
 

--- a/src/app/code/community/Zendesk/Zendesk/Model/Api/Users.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Api/Users.php
@@ -19,7 +19,7 @@ class Zendesk_Zendesk_Model_Api_Users extends Zendesk_Zendesk_Model_Api_Abstract
 {
     public function find($email)
     {
-        if(!Zend_Validate::is($email, 'EmailAddress')) {
+        if(!Zend_Validate::is($email, 'EmailAddress', array('domain' => false))) {
             throw new InvalidArgumentException('Invalid email address provided');
         }
 

--- a/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
@@ -80,7 +80,7 @@ class Zendesk_Zendesk_Model_Observer
             // If the email is already set, then do nothing
             if($currentEmail !== $zendeskEmail) {
                 // Ensure the email address value exists and is valid
-                if(Zend_Validate::is($zendeskEmail, 'EmailAddress')) {
+                if(Zend_Validate::is($zendeskEmail, 'EmailAddress', array('domain' => false))) {
                     Mage::getModel('core/config')->saveConfig('zendesk/hidden/contact_email_old', $currentEmail, $scope, $scopeId);
                     Mage::getModel('core/config')->saveConfig('contacts/email/recipient_email', $zendeskEmail, $scope, $scopeId);
                 }

--- a/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
@@ -359,7 +359,7 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
                 // If the email is already set, then do nothing
                 if($currentEmail !== $zendeskEmail) {
                     // Ensure the email address value exists and is valid
-                    if(Zend_Validate::is($zendeskEmail, 'EmailAddress')) {
+                    if(Zend_Validate::is($zendeskEmail, 'EmailAddress', array('domain' => false))) {
                         Mage::getModel('core/config')->saveConfig('zendesk/hidden/contact_email_old', $currentEmail);
                         Mage::getModel('core/config')->saveConfig('contacts/email/recipient_email', $zendeskEmail);
                     }


### PR DESCRIPTION
`Zend_Validate::is($email, 'EmailAddress')` does not allow the usage of new TLDs like `.cloud`. If you try to use a mail address like `test@test.cloud`, which is valid, an exception is thrown. This PR fixes this issue by disabling the domain check. The domain cannot really be checked reliably since quite many TLDs are now valid.

Related: https://stackoverflow.com/questions/25011227/magento-hostname-validation-errors