### PR TITLE
Fix wrong condition, results in the snippet always being re-saved.

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
+++ b/src/app/code/community/Zendesk/Zendesk/Model/Observer.php
@@ -111,8 +111,8 @@ class Zendesk_Zendesk_Model_Observer
             }
 
             // Case insensitive search with single and double quotes, still better performance than 1 regexp search
-            $hasUnatchedSnippet = stripos($widgetSnippet, "'{$zDomain}'") === false && stripos($widgetSnippet, '"'.$zDomain.'"') === false;
-            if (! $hasUnmatchedSnippet) {
+            $missingSnippet = stripos($widgetSnippet, "'{$zDomain}'") === false && stripos($widgetSnippet, '"'.$zDomain.'"') === false;
+            if ($missingSnippet) {
                 $webWidgetSnippet=<<<EOJS
 <!-- Start of Zendesk Widget script -->
 <script>/*<![CDATA[*/window.zEmbed||function(e,t){var n,o,d,i,s,a=[],r=document.createElement("iframe");window.zEmbed=function(){a.push(arguments)},window.zE=window.zE||window.zEmbed,r.src="javascript:false",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="display: none",d=document.getElementsByTagName("script"),d=d[d.length-1],d.parentNode.insertBefore(r,d),i=r.contentWindow,s=i.document;try{o=s}catch(c){n=document.domain,r.src='javascript:var d=document.open();d.domain="'+n+'";void(0);',o=s}o.open()._l=function(){var o=this.createElement("script");n&&(this.domain=n),o.id="js-iframe-async",o.src=e,this.t=+new Date,this.zendeskHost=t,this.zEQueue=a,this.body.appendChild(o)},o.write('<body onload="document._l();">'),o.close()}("https://assets.zendesk.com/embeddable_framework/main.js","{$zDomain}");/*]]>*/</script>


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

This fixes a bad condition I introduced in this commit: https://github.com/zendesk/magento_extension/pull/132/commits/ca2f69f918272f33f63fe52b9c5994f155850033

There was a typo in the variable name and the if condition was incorrect :man_facepalming: 

Fortunately, there is no bug caused by this. The bad condition just resulted in the snippet always being stored in the db every time the config is saved, one unnecessary write. Ironically enough, it was because of the variable typo that the bad if-condition did not cause a bug.

### Risks
* [low] variable naming could further introduce confusion over this already pretty verbose conditional, hopefully made it more concise.