### PR TITLE
Fix for Mage::registry() check for PHP 7

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
@@ -419,7 +419,7 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
     public function storeDependenciesInCachedRegistry() {
         $cache = Mage::app()->getCache();
 
-        if (null == Mage::registry('zendesk_groups')) {
+        if (null === Mage::registry('zendesk_groups')) {
             if( $cache->load('zendesk_groups') === false) {
                 $groups = serialize( Mage::getModel('zendesk/api_groups')->all() );
                 $cache->save($groups, 'zendesk_groups', array('zendesk', 'zendesk_groups'), 1200);


### PR DESCRIPTION
In PHP 7, I keep getting exception thrown with a message: "Mage registry key zendesk_groups already exists" because the null value returned from Mage::registry('zendesk_groups') must be with 3 equal signs so it can check the type as well.