### PR TITLE
Customers API : Filter order collection by customer ID for performance cause

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/ApiController.php
@@ -139,25 +139,26 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
 
         $sections = explode('/', trim($this->getRequest()->getPathInfo(), '/'));
         $email = $sections[3];
-
-        // Get a list of all orders for the given email address
-        // This is used to determine if a missing customer is a guest or if they really aren't a customer at all
-        $orderCollection = Mage::getModel('sales/order')->getCollection()
-            ->addFieldToFilter('customer_email', array('eq' => array($email)));
-        $orders = array();
-        if($orderCollection->getSize()) {
-            foreach($orderCollection as $order) {
-                $orders[] = Mage::helper('zendesk')->getOrderDetail($order);
-            }
-        }
+        $websiteId = Mage::app()->getWebsite()->getId();
 
         // Try to load a corresponding customer object for the provided email address
-        $customer = Mage::helper('zendesk')->loadCustomer($email);
-
-        // if the admin site has a custom URL, use it
-        $urlModel = Mage::getModel('adminhtml/url')->setStore('admin');
+        $customer = Mage::helper('zendesk')->loadCustomer($email, $websiteId);
 
         if($customer && $customer->getId()) {
+            // Get a list of all orders for the given customer ID
+            $orderCollection = Mage::getModel('sales/order')->getCollection()
+                ->addFieldToFilter('customer_id', array('eq' => array($customer->getId())));
+            $orders = array();
+
+            // if the admin site has a custom URL, use it
+            $urlModel = Mage::getModel('adminhtml/url')->setStore('admin');
+
+            if($orderCollection->getSize()) {
+                foreach($orderCollection as $order) {
+                    $orders[] = Mage::helper('zendesk')->getOrderDetail($order);
+                }
+            }
+
             $info = array(
                 'guest' => false,
                 'id' => $customer->getId(),
@@ -180,6 +181,17 @@ class Zendesk_Zendesk_ApiController extends Mage_Core_Controller_Front_Action
             }
 
         } else {
+            // Get a list of all orders for the given email address
+            $orderCollection = Mage::getModel('sales/order')->getCollection()
+                ->addFieldToFilter('customer_email', array('eq' => array($email)));
+            $orders = array();
+
+            if($orderCollection->getSize()) {
+                foreach($orderCollection as $order) {
+                    $orders[] = Mage::helper('zendesk')->getOrderDetail($order);
+                }
+            }
+
             if(count($orders) == 0) {
                 // The email address doesn't even correspond with a guest customer
                 $this->getResponse()


### PR DESCRIPTION
Filter by customer email on each request takes a long time on large order collection and creates performance issues (slow queries in database):

`# Query_time: 2.330689 Lock_time: 0.000100 Rows_sent: 3 Rows_examined: 372888
SELECT main_table.* FROM sales_flat_order AS main_table WHERE (customer_email = 'xxxxxxxxx@gmail.com');`

It is much faster to filter by customer ID if customer exists, and filter by email only if required.