### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Helper/Log.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Log.php
@@ -84,7 +84,7 @@ class Zendesk_Zendesk_Helper_Log extends Mage_Core_Helper_Abstract
     {
         $size = $this->getLogSize();
 
-        if($size !== FALSE && $size > self::MAX_LOG_SIZE) {
+        if($size !== false && $size > self::MAX_LOG_SIZE) {
             return true;
         }
 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!