### PR TITLE
[PEGASUS-934] Escape user input when generating autocompelete list HTML to avoid XSS attacks

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -417,9 +417,9 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
         $output = '<ul>';
         if($customers->getSize()) {
             foreach($customers as $customer) {
-                $id = $customer->getId();
-                $name = $customer->getName();
-                $email = $customer->getEmail();
+                $id = htmlspecialchars($customer->getId(), ENT_COMPAT, 'UTF-8');
+                $name = htmlspecialchars($customer->getName(), ENT_COMPAT, 'UTF-8');
+                $email = htmlspecialchars($customer->getEmail(), ENT_COMPAT, 'UTF-8');
                 $output .= '<li id="customer-' . $id . '" data-email="' . $email . '" data-name="' . $name . '">' . $name . ' &lt;' . $email . '&gt;</li>';
             }
         }


### PR DESCRIPTION
https://zendesk.atlassian.net/browse/PEGASUS-934

Context

> Currently in the magento extension admin page, an admin can create a new zendesk ticket via a form.
> 
> One of the fields is to use the customer details from magento, end users can add any text to this field,  including html tags (script, links etc..). 
> 
> When an admin searches this field, it will auto complete and render the text to the webpage. Currently we don’t sanitise the text input before we render it to the webpage opening us to run malicious scripts (XSS attack).
> 
> As part of the extension we offer the ability to create a ticket on behalf of a customer in Magento. Our autocomplete feature within the extension will automatically populate the fields necessary for a ticket, however, the function does not appear to perform any sanitization or encoding of the Magento customer data retrieved. This can allow for attacks such as Stored XSS (Cross-Site Scripting) within the Magento admin console which we would consider a High vulnerability. In this case we believe that Magento could take steps to validate data upon intake, however we should also take steps to sanitize this data.
> 
> Link: https://support.zendesk.com/agent/tickets/5475610

With the fix, autocorrect HTML is rendered with sanitised user input:
![Screen Shot 2020-06-22 at 2 04 29 pm](https://user-images.githubusercontent.com/53257/85247518-5f477e80-b491-11ea-87c2-a53c0682ad7b.png)

Note how the above page didn't execute the injected code but instead escaped it and rendered it.


Can test with https://github.com/zendesk/magento-k8s/pull/5