### PR TITLE
[PEGASUS-932] Redact JWT token from logs

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -172,11 +172,6 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
             $payload['external_id'] = $user->getId();
         }
 
-        // Redact token then log the rest of the payload
-        $jti_redacted_payload = $payload; // arrays are copied by value in php, not just a ref being passed around
-        $jti_redacted_payload["jti"] = "REDACTED";
-        Mage::log('Admin JWT: ' . var_export($jti_redacted_payload, true), null, 'zendesk.log');
-
         $jwt = JWT::encode($payload, $token);
         $return = $return_url ? "&return_to=".$return_url : "";
 

--- a/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/Adminhtml/ZendeskController.php
@@ -172,7 +172,10 @@ class Zendesk_Zendesk_Adminhtml_ZendeskController extends Mage_Adminhtml_Control
             $payload['external_id'] = $user->getId();
         }
 
-        Mage::log('Admin JWT: ' . var_export($payload, true), null, 'zendesk.log');
+        // Redact token then log the rest of the payload
+        $jti_redacted_payload = $payload; // arrays are copied by value in php, not just a ref being passed around
+        $jti_redacted_payload["jti"] = "REDACTED";
+        Mage::log('Admin JWT: ' . var_export($jti_redacted_payload, true), null, 'zendesk.log');
 
         $jwt = JWT::encode($payload, $token);
         $return = $return_url ? "&return_to=".$return_url : "";

--- a/src/app/code/community/Zendesk/Zendesk/controllers/SsoController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/SsoController.php
@@ -75,7 +75,10 @@ class Zendesk_Zendesk_SsoController extends Mage_Core_Controller_Front_Action
             $payload['external_id'] = $user->getId();
         }
 
-        Mage::log('End-user JWT: ' . var_export($payload, true), null, 'zendesk.log');
+        // Redact token then log the rest of the payload
+        $jti_redacted_payload = $payload; // arrays are copied by value in php, not just a ref being passed around
+        $jti_redacted_payload["jti"] = "REDACTED";
+        Mage::log('End-user JWT: ' . var_export($jti_redacted_payload, true), null, 'zendesk.log');
 
         $jwt = JWT::encode($payload, $token);
         $return_url = $return_url ? "&return_to=".$return_url : "";

--- a/src/app/code/community/Zendesk/Zendesk/controllers/SsoController.php
+++ b/src/app/code/community/Zendesk/Zendesk/controllers/SsoController.php
@@ -75,11 +75,6 @@ class Zendesk_Zendesk_SsoController extends Mage_Core_Controller_Front_Action
             $payload['external_id'] = $user->getId();
         }
 
-        // Redact token then log the rest of the payload
-        $jti_redacted_payload = $payload; // arrays are copied by value in php, not just a ref being passed around
-        $jti_redacted_payload["jti"] = "REDACTED";
-        Mage::log('End-user JWT: ' . var_export($jti_redacted_payload, true), null, 'zendesk.log');
-
         $jwt = JWT::encode($payload, $token);
         $return_url = $return_url ? "&return_to=".$return_url : "";
         


### PR DESCRIPTION
# Context
https://zendesk.atlassian.net/browse/PEGASUS-932

> We are logging sensitive information, such as Zendesk JWT Tokens as well as agent and customer PII, to var/log/zendesk.log in plaintext on the server hosting the Magento installation. We have ranked this as a Moderate vulnerability based on that it required malicious access to the server in question to exploit.
> 
> Link: https://support.zendesk.com/agent/tickets/5475611