### PR TITLE
Fix: undefined array key 1 - Address2 not set

### DIFF
--- a/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
+++ b/src/app/code/community/Zendesk/Zendesk/Helper/Data.php
@@ -457,7 +457,7 @@ class Zendesk_Zendesk_Helper_Data extends Mage_Core_Helper_Abstract
     
             $street = $address->getStreet();
             $addressData['line_1'] = $street[0] ?: '';
-            $addressData['line_2'] = $street[1] ?: '';
+            $addressData['line_2'] = isset($street[1]) ? $street[1] : '';
         }
 
         return $addressData;


### PR DESCRIPTION
PHP 8 throws this error because address line 2 is not always set. `Warning: Undefined array key 1  in /var/www/braende24syv.dk/public_html/app/code/community/Zendesk/Zendesk/Helper/Data.php on line 460`